### PR TITLE
Cleanup useless dependencies and improve test coverage

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,7 @@
     }
   },
   "env": {
+    "es6": true,
     "browser": true,
     "jest/globals": true
   },
@@ -24,6 +25,7 @@
     "semi": ["error", "never"],
     "react-native/no-color-literals": 0,
     "react-native/no-inline-styles": 0,
+    "react-native/split-platform-components": 0,
     "react/display-name": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "react": "16.5.0",
     "react-i18next": "^8.2.0",
     "react-native": "^0.57.1",
-    "react-native-image-offline": "^0.1.2",
     "react-native-languages": "^3.0.0",
     "react-native-splash-screen": "^3.0.6",
     "react-native-vector-icons": "^6.0.2",

--- a/src/__mocks__/react-native-languages.js
+++ b/src/__mocks__/react-native-languages.js
@@ -1,0 +1,3 @@
+export default {
+  language: 'es'
+}

--- a/src/__tests__/i18n.test.js
+++ b/src/__tests__/i18n.test.js
@@ -1,0 +1,28 @@
+import i18n, { setLanguage } from '../i18n'
+import * as store from '../redux/store'
+
+describe('i18n', () => {
+  it('has English as default language', () => {
+    expect(i18n.language).toBe('en')
+  })
+  it('has both English and Spanish translations loaded as resources', () => {
+    expect(i18n.options.resources.en).toEqual(expect.any(Object))
+    expect(i18n.options.resources.es).toEqual(expect.any(Object))
+  })
+  it('setLanguage gets the correct language from the store', () => {
+    store.default.getState = () => ({
+      language: 'es'
+    })
+
+    setLanguage()
+    expect(i18n.language).toBe('es')
+  })
+  it('setLanguage gets sets the default language if the store has no language set', () => {
+    store.default.getState = () => ({
+      language: false
+    })
+
+    setLanguage()
+    expect(i18n.language).toBe('en')
+  })
+})

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -206,7 +206,7 @@ const LifemapStack = createStackNavigator({
   ...DraftScreens
 })
 
-const FamiliesStack = createStackNavigator({
+export const FamiliesStack = createStackNavigator({
   Families: {
     screen: FamiliesView,
     navigationOptions: ({ navigation }) => ({

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -68,6 +68,7 @@ class Slider extends Component {
         </ScrollView>
         <View style={styles.nav}>
           <TouchableOpacity
+            id="go-left"
             style={styles.iconSmall}
             onPress={() =>
               this._scrollView.scrollTo({ x: 0, y: 0, animated: true })
@@ -84,6 +85,7 @@ class Slider extends Component {
             <Icon name="done" size={56} color={colors.white} />
           </View>
           <TouchableOpacity
+            id="go-right"
             style={styles.iconSmall}
             onPress={() => this._scrollView.scrollToEnd({ animated: true })}
           >

--- a/src/components/__tests__/Button.test.js
+++ b/src/components/__tests__/Button.test.js
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme'
 import { TouchableOpacity, Text } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import Button from '../Button'
+import colors from '../../theme.json'
 
 const createTestProps = props => ({
   ...props,
@@ -33,6 +34,18 @@ describe('Button Component', () => {
     })
     it('does not render <Icon /> when icon property is not defined', () => {
       expect(wrapper.find(Icon)).toHaveLength(0)
+    })
+    it('has proper backgroundColor and text color when passed colored = true', () => {
+      props = createTestProps({
+        colored: true
+      })
+      wrapper = shallow(<Button {...props} />)
+
+      expect(wrapper.find(TouchableOpacity).props().style.backgroundColor).toBe(
+        colors.palegreen
+      )
+
+      expect(wrapper.find(Text).props().style.color).toBe(colors.white)
     })
   })
   describe('functionality', () => {

--- a/src/components/__tests__/Loading.test.js
+++ b/src/components/__tests__/Loading.test.js
@@ -2,7 +2,6 @@ import React from 'react'
 
 import { shallow } from 'enzyme'
 import { Text, ActivityIndicator, View } from 'react-native'
-import Icon from 'react-native-vector-icons/MaterialIcons'
 import Loading from '../Loading'
 
 const createTestProps = props => ({

--- a/src/components/__tests__/Navigation.test.js
+++ b/src/components/__tests__/Navigation.test.js
@@ -1,7 +1,12 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { Image } from 'react-native'
-import { AppStack, DrawerContent, generateNavOptions } from '../Navigation'
+import {
+  AppStack,
+  DrawerContent,
+  generateNavOptions,
+  FamiliesStack
+} from '../Navigation'
 
 describe('Navigation', () => {
   describe('Drawer', () => {
@@ -22,7 +27,15 @@ describe('Navigation', () => {
         })
       )
     })
-    it('navigates to proper views', () => {})
+    it('can navigate to all views', () => {
+      expect(wrapper.instance()._navigation.navigate('Families')).toBe(true)
+      expect(wrapper.instance()._navigation.navigate('Surveys')).toBe(true)
+      expect(wrapper.instance()._navigation.navigate('Dashboard')).toBe(true)
+      expect(wrapper.instance()._navigation.navigate('Sync')).toBe(true)
+      expect(wrapper.instance()._navigation.navigate('Family')).toBe(true)
+      expect(wrapper.instance()._navigation.navigate('Draft')).toBe(true)
+      expect(wrapper.instance()._navigation.navigate('Question')).toBe(true)
+    })
   })
   describe('DrawerContent', () => {
     const wrapper = shallow(

--- a/src/components/__tests__/RoundImage.test.js
+++ b/src/components/__tests__/RoundImage.test.js
@@ -2,7 +2,6 @@ import React from 'react'
 
 import { shallow } from 'enzyme'
 import { Image } from 'react-native'
-import Icon from 'react-native-vector-icons/MaterialIcons'
 import RoundImage from '../RoundImage'
 
 const createTestProps = props => ({

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -14,6 +14,8 @@ const resources = {
   }
 }
 
+/* eslint-disable import/no-named-as-default-member */
+
 // set language after store rehydration
 export const setLanguage = () => {
   const reduxLanguage = store.getState().language

--- a/src/redux/__tests__/reducer.test.js
+++ b/src/redux/__tests__/reducer.test.js
@@ -124,6 +124,24 @@ describe('drafts reducer', () => {
       })
     ).toEqual([...initialStore, { ...payload, status: 'In progress' }])
   })
+  it('should handle SUBMIT_DRAFT', () => {
+    const expectedStore = [
+      {
+        draft_id: 1,
+        status: 'Pending'
+      },
+      {
+        draft_id: 2,
+        status: 'In progress'
+      }
+    ]
+    expect(
+      reducer.drafts(initialStore, {
+        type: action.SUBMIT_DRAFT,
+        id: 1
+      })
+    ).toEqual(expectedStore)
+  })
   it('should handle SUBMIT_DRAFT_COMMIT', () => {
     const expectedStore = [
       {

--- a/src/redux/__tests__/store.test.js
+++ b/src/redux/__tests__/store.test.js
@@ -1,0 +1,20 @@
+import store, { getHydrationState } from '../store'
+
+describe('store', () => {
+  it('getHydrationState returns proper state', () => {
+    expect(getHydrationState()).toBe(false)
+  })
+  it('store has all reducers', () => {
+    expect(store.getState()).toEqual(
+      expect.objectContaining({
+        env: 'production',
+        drafts: expect.any(Array),
+        families: expect.any(Array),
+        snapshots: expect.any(Array),
+        surveys: expect.any(Array),
+        offline: expect.any(Object),
+        user: expect.any(Object)
+      })
+    )
+  })
+})

--- a/src/screens/Login.js
+++ b/src/screens/Login.js
@@ -80,7 +80,7 @@ export class Login extends Component {
               color: colors.lightdark
             }}
           >
-            {"Let's get started..."}
+            Let&lsquo;s get started...
           </Text>
           <Text style={globalStyles.h5}>USERNAME</Text>
           <TextInput

--- a/src/screens/__mocks__/react-native-languages.js
+++ b/src/screens/__mocks__/react-native-languages.js
@@ -1,3 +1,0 @@
-const mockedModule = jest.mock('react-native-languages')
-
-export default mockedModule

--- a/src/screens/__tests__/BeginLifemap.test.js
+++ b/src/screens/__tests__/BeginLifemap.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { ScrollView, FlatList, Text } from 'react-native'
+import { ScrollView, Text } from 'react-native'
 import { BeginLifemap } from '../lifemap/BeginLifemap'
 import RoundImage from '../../components/RoundImage'
 import Button from '../../components/Button'

--- a/src/screens/__tests__/Login.test.js
+++ b/src/screens/__tests__/Login.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { ScrollView, TextInput, Text, TouchableOpacity } from 'react-native'
+import { ScrollView, TextInput, Text } from 'react-native'
 import Button from '../../components/Button'
 import { Login } from '../Login'
 

--- a/src/screens/__tests__/Question.test.js
+++ b/src/screens/__tests__/Question.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { ScrollView, Text, ProgressBarAndroid, View } from 'react-native'
+import { ScrollView, Text, ProgressBarAndroid } from 'react-native'
 import { Question } from '../lifemap/Question'
 import Slider from '../../components/Slider'
 

--- a/src/screens/lifemap/BeginLifemap.js
+++ b/src/screens/lifemap/BeginLifemap.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types'
 import globalStyles from '../../globalStyles'
 import RoundImage from '../../components/RoundImage'
 import Button from '../../components/Button'
-import colors from '../../theme.json'
 
 export class BeginLifemap extends Component {
   numberOfQuestions = this.props.navigation.getParam('survey')[

--- a/src/screens/lifemap/Draft.js
+++ b/src/screens/lifemap/Draft.js
@@ -13,7 +13,6 @@ import { connect } from 'react-redux'
 import uuid from 'uuid/v1'
 
 import { createDraft, addSurveyData, submitDraft } from '../../redux/actions'
-import { url } from '../../config'
 
 export class Draft extends Component {
   //Get draft id from Redux store if it exists else create new draft id
@@ -84,9 +83,7 @@ export class Draft extends Component {
 
   render() {
     const { orderedQuestions, questionProperties } = this
-    const draft = this.props.drafts.filter(
-      draft => draft.draft_id === this.draft_id
-    )[0]
+
     return (
       <ScrollView style={styles.container}>
         <Button


### PR DESCRIPTION
This is as far as I was able to do this with the current timeframe. I spent a lot of time figuring out how to test `react-navigation` more in depth, but to no avail. I just can't get the child stacks to show their properties. Also `FlatList`s seem to render 0 children on `shallow(comp)`. There is a [workaround](https://stackoverflow.com/questions/37324329/how-to-test-reactnative-listview-item-with-enzyme), but for now I have not time to apply it everywhere.