### PR TITLE
Fix #86 - get images from cache when possible as RN disables images

### DIFF
--- a/src/components/CachedImage.js
+++ b/src/components/CachedImage.js
@@ -1,12 +1,5 @@
 import React, { Component } from 'react'
-import {
-  Image,
-  Platform,
-  NetInfo,
-  View,
-  ActivityIndicator,
-  StyleSheet
-} from 'react-native'
+import { Image, Platform, NetInfo } from 'react-native'
 import PropTypes from 'prop-types'
 import RNFetchBlob from 'rn-fetch-blob'
 
@@ -16,13 +9,15 @@ export class CachedImage extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      source: false
+      source: props.source
     }
   }
   getProperSourceForOS(source) {
     return Platform.OS === 'android' ? 'file://' + source : '' + source
   }
-  checkIfCached() {
+  checkIfCached() {}
+
+  updateSource() {
     const { source } = this.props
 
     RNFetchBlob.fs
@@ -37,37 +32,19 @@ export class CachedImage extends Component {
         }
       })
   }
-  updateSource(online) {
-    if (online) {
-      this.setState({
-        source: this.props.source
-      })
-    } else {
-      this.checkIfCached()
-    }
-  }
   componentDidMount() {
-    // check if connected on mount
-    NetInfo.isConnected.fetch().then(async online => {
-      this.updateSource(online)
-    })
+    this.updateSource()
 
     // add event on net change
-    NetInfo.addEventListener('connectionChange', online => {
-      this.updateSource(online)
+    NetInfo.addEventListener('connectionChange', () => {
+      this.updateSource()
     })
   }
   render() {
     const { source } = this.state
     const { style } = this.props
 
-    return source ? (
-      <Image style={style} source={{ uri: source }} />
-    ) : (
-      <View style={[styles.placeholder, style]}>
-        <ActivityIndicator size="large" />
-      </View>
-    )
+    return <Image style={style} source={{ uri: source }} />
   }
 }
 
@@ -75,12 +52,5 @@ CachedImage.propTypes = {
   source: PropTypes.string,
   style: PropTypes.object
 }
-
-const styles = StyleSheet.create({
-  placeholder: {
-    alignItems: 'center',
-    justifyContent: 'center'
-  }
-})
 
 export default CachedImage

--- a/src/components/__tests__/CachedImage.test.js
+++ b/src/components/__tests__/CachedImage.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { Image, Platform, ActivityIndicator } from 'react-native'
+import { Image, Platform } from 'react-native'
 import { CachedImage } from '../CachedImage'
 
 const createTestProps = props => ({
@@ -18,11 +18,8 @@ describe('CachedImage', () => {
     })
     it('has proper initial state', () => {
       expect(wrapper).toHaveState({
-        source: false
+        source: 'some.url.png'
       })
-    })
-    it('shows ActivityIndicator while loading state', () => {
-      expect(wrapper.find(ActivityIndicator)).toHaveLength(1)
     })
   })
   describe('after net check', () => {
@@ -41,7 +38,8 @@ describe('CachedImage', () => {
         Platform.OS === 'android' ? 'file://some.url.png' : 'some.url.png'
       )
       expect(wrapper.find(Image)).toHaveProp('source', {
-        uri: Platform.OS === 'android' ? 'file://some.url.png' : 'some.url.png'
+        uri:
+          Platform.OS === 'android' ? 'file://some.url.png' : 'foo/some.url.png'
       })
     })
 


### PR DESCRIPTION
Turns out react native is turning off images at some point: https://github.com/facebook/react-native/issues/7408, https://github.com/facebook/react-native/issues/13600, https://github.com/facebook/react-native/issues/9581#issuecomment-287945948. At this stage we will always get images from cache even online if available.