### PR TITLE
Status bar and family member count fixes

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,6 +1,5 @@
 <resources>
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
          <item name="android:statusBarColor">@color/palebeige</item>
-         <item name="android:windowLightStatusBar">@color/primary_dark</item>
     </style>
 </resources>

--- a/src/components/NavWrapper.js
+++ b/src/components/NavWrapper.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react'
-import { View, StyleSheet } from 'react-native'
+import { View, StyleSheet, StatusBar } from 'react-native'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { getHydrationState } from '../redux/store'
 import { LoginStack, AppStack } from './navigation'
 import Loading from './Loading'
+import colors from '../theme.json'
 
 export class NavWrapper extends Component {
   state = {
@@ -42,12 +43,17 @@ export class NavWrapper extends Component {
     this.clearTimers()
   }
   render() {
-    return this.state.rehydrated ? (
+    return (
       <View style={styles.container}>
-        {this.props.user.token ? <AppStack /> : <LoginStack />}
+        <StatusBar backgroundColor={colors.palebeige} barStyle="dark-content" />
+        {this.state.rehydrated ? (
+          <View style={styles.container}>
+            {this.props.user.token ? <AppStack /> : <LoginStack />}
+          </View>
+        ) : (
+          <Loading time={this.state.loadingTime} />
+        )}
       </View>
-    ) : (
-      <Loading time={this.state.loadingTime} />
     )
   }
 }

--- a/src/components/__tests__/NavWrapper.test.js
+++ b/src/components/__tests__/NavWrapper.test.js
@@ -1,9 +1,11 @@
 import React from 'react'
 import { shallow } from 'enzyme'
+import { StatusBar } from 'react-native'
 import { NavWrapper } from '../NavWrapper'
 import { LoginStack, AppStack } from '../navigation'
 import Loading from '../Loading'
 import * as store from '../../redux/store'
+import colors from '../../theme.json'
 
 jest.useFakeTimers()
 
@@ -25,6 +27,12 @@ describe('Navigation Wrapper', () => {
   })
 
   describe('before rehydration', () => {
+    it('displaye status bar with contrasting colors', () => {
+      expect(wrapper.find(StatusBar)).toHaveProp({
+        backgroundColor: colors.palebeige,
+        barStyle: 'dark-content'
+      })
+    })
     it('checks for store hydration on mount', () => {
       expect(wrapper).toHaveState({
         rehydrated: false

--- a/src/redux/__tests__/actions.test.js
+++ b/src/redux/__tests__/actions.test.js
@@ -163,6 +163,17 @@ describe('drafts actions', () => {
     }
     expect(action.deleteDraft(id)).toEqual(expectedAction)
   })
+  it('should create an action to remove family memvers from draft', () => {
+    const id = 1
+    const afterIndex = 2
+
+    const expectedAction = {
+      type: action.REMOVE_FAMILY_MEMBERS,
+      id,
+      afterIndex
+    }
+    expect(action.removeFamilyMembers(id, afterIndex)).toEqual(expectedAction)
+  })
   it('should create an action to add survey data to draft', () => {
     const id = 1
     const category = 'category'

--- a/src/redux/__tests__/reducer.test.js
+++ b/src/redux/__tests__/reducer.test.js
@@ -115,7 +115,8 @@ describe('drafts reducer', () => {
     {
       draftId: 2,
       status: 'In progress',
-      priorities: [{ indicator: 'phone', action: 'Action', reason: 'reason' }]
+      priorities: [{ indicator: 'phone', action: 'Action', reason: 'reason' }],
+      familyData: { familyMembersList: [({ name: 'Joan' }, { name: 'Jane' })] }
     }
   ]
   it('should handle CREATE_DRAFT', () => {
@@ -138,7 +139,12 @@ describe('drafts reducer', () => {
       {
         draftId: 2,
         status: 'In progress',
-        priorities: [{ indicator: 'phone', action: 'Action', reason: 'reason' }]
+        priorities: [
+          { indicator: 'phone', action: 'Action', reason: 'reason' }
+        ],
+        familyData: {
+          familyMembersList: [({ name: 'Joan' }, { name: 'Jane' })]
+        }
       }
     ]
     expect(
@@ -157,7 +163,12 @@ describe('drafts reducer', () => {
       {
         draftId: 2,
         status: 'Success',
-        priorities: [{ indicator: 'phone', action: 'Action', reason: 'reason' }]
+        priorities: [
+          { indicator: 'phone', action: 'Action', reason: 'reason' }
+        ],
+        familyData: {
+          familyMembersList: [({ name: 'Joan' }, { name: 'Jane' })]
+        }
       }
     ]
     expect(
@@ -176,7 +187,12 @@ describe('drafts reducer', () => {
       {
         draftId: 2,
         status: 'Error',
-        priorities: [{ indicator: 'phone', action: 'Action', reason: 'reason' }]
+        priorities: [
+          { indicator: 'phone', action: 'Action', reason: 'reason' }
+        ],
+        familyData: {
+          familyMembersList: [({ name: 'Joan' }, { name: 'Jane' })]
+        }
       }
     ]
     expect(
@@ -196,7 +212,12 @@ describe('drafts reducer', () => {
         draftId: 2,
         personal_survey_data: { name: 'Name' },
         status: 'In progress',
-        priorities: [{ indicator: 'phone', action: 'Action', reason: 'reason' }]
+        priorities: [
+          { indicator: 'phone', action: 'Action', reason: 'reason' }
+        ],
+        familyData: {
+          familyMembersList: [({ name: 'Joan' }, { name: 'Jane' })]
+        }
       }
     ]
     expect(
@@ -205,6 +226,31 @@ describe('drafts reducer', () => {
         id: 2,
         category: 'personal_survey_data',
         payload: { name: 'Name' }
+      })
+    ).toEqual(expectedStore)
+  })
+  it('should handle REMOVE_FAMILY_MEMBERS', () => {
+    const expectedStore = [
+      {
+        draftId: 1,
+        status: 'Success'
+      },
+      {
+        draftId: 2,
+        status: 'In progress',
+        priorities: [
+          { indicator: 'phone', action: 'Action', reason: 'reason' }
+        ],
+        familyData: {
+          familyMembersList: [{ name: 'Jane' }]
+        }
+      }
+    ]
+    expect(
+      reducer.drafts(initialStore, {
+        type: action.REMOVE_FAMILY_MEMBERS,
+        id: 2,
+        afterIndex: 1
       })
     ).toEqual(expectedStore)
   })
@@ -220,7 +266,10 @@ describe('drafts reducer', () => {
         priorities: [
           { indicator: 'phone', action: 'Action', reason: 'reason' },
           { indicator: 'Income', action: 'Some action' }
-        ]
+        ],
+        familyData: {
+          familyMembersList: [({ name: 'Joan' }, { name: 'Jane' })]
+        }
       }
     ]
     expect(
@@ -247,7 +296,10 @@ describe('drafts reducer', () => {
             action: 'Changed action',
             reason: 'Changed reason'
           }
-        ]
+        ],
+        familyData: {
+          familyMembersList: [({ name: 'Joan' }, { name: 'Jane' })]
+        }
       }
     ]
     expect(

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -112,6 +112,7 @@ export const ADD_SURVEY_FAMILY_MEMBER_DATA = 'ADD_SURVEY_FAMILY_MEMBER_DATA'
 export const SUBMIT_DRAFT = 'SUBMIT_DRAFT'
 export const SUBMIT_DRAFT_COMMIT = 'SUBMIT_DRAFT_COMMIT'
 export const SUBMIT_DRAFT_ROLLBACK = 'SUBMIT_DRAFT_ROLLBACK'
+export const REMOVE_FAMILY_MEMBERS = 'REMOVE_FAMILY_MEMBERS'
 
 export const createDraft = payload => ({
   type: CREATE_DRAFT,
@@ -145,6 +146,12 @@ export const addSurveyFamilyMemberData = ({
   index,
   isSocioEconomicAnswer,
   payload
+})
+
+export const removeFamilyMembers = (id, afterIndex) => ({
+  type: REMOVE_FAMILY_MEMBERS,
+  id,
+  afterIndex
 })
 
 export const addSurveyData = (id, category, payload) => ({

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -8,6 +8,7 @@ import {
   ADD_SURVEY_DATA,
   ADD_SURVEY_PRIORITY_ACHEIVEMENT_DATA,
   ADD_SURVEY_FAMILY_MEMBER_DATA,
+  REMOVE_FAMILY_MEMBERS,
   DELETE_DRAFT,
   LOAD_SNAPSHOTS,
   SUBMIT_DRAFT,
@@ -298,35 +299,47 @@ export const drafts = (state = [], action) => {
         }
       })
 
-    case SUBMIT_DRAFT:
-      return state.map(
-        draft =>
-          draft.draftId === action.id
-            ? {
-                ...draft,
-                status: 'Pending'
+    case REMOVE_FAMILY_MEMBERS:
+      return state.map(draft =>
+        draft.draftId === action.id
+          ? {
+              ...draft,
+              familyData: {
+                ...draft.familyData,
+                familyMembersList: draft.familyData.familyMembersList.filter(
+                  (item, index) => index < action.afterIndex
+                )
               }
-            : draft
+            }
+          : draft
+      )
+
+    case SUBMIT_DRAFT:
+      return state.map(draft =>
+        draft.draftId === action.id
+          ? {
+              ...draft,
+              status: 'Pending'
+            }
+          : draft
       )
     case SUBMIT_DRAFT_COMMIT:
-      return state.map(
-        draft =>
-          draft.draftId === action.meta.id
-            ? {
-                ...draft,
-                status: 'Success'
-              }
-            : draft
+      return state.map(draft =>
+        draft.draftId === action.meta.id
+          ? {
+              ...draft,
+              status: 'Success'
+            }
+          : draft
       )
     case SUBMIT_DRAFT_ROLLBACK:
-      return state.map(
-        draft =>
-          draft.draftId === action.meta.id
-            ? {
-                ...draft,
-                status: 'Error'
-              }
-            : draft
+      return state.map(draft =>
+        draft.draftId === action.meta.id
+          ? {
+              ...draft,
+              status: 'Error'
+            }
+          : draft
       )
     case DELETE_DRAFT:
       return state.filter(draft => draft.draftId !== action.id)

--- a/src/screens/__tests__/FamilyMembersNames.test.js
+++ b/src/screens/__tests__/FamilyMembersNames.test.js
@@ -43,6 +43,7 @@ const createTestProps = props => ({
     }
   ],
   addSurveyData: jest.fn(),
+  removeFamilyMembers: jest.fn(),
   addSurveyFamilyMemberData: jest.fn(),
   ...props
 })
@@ -127,6 +128,48 @@ describe('FamilyMembersNames View', () => {
         .last()
         .props().disabled
     ).toBe(false)
+  })
+  it('changes family members count', () => {
+    wrapper
+      .find('#familyMembersCount')
+      .props()
+      .onChange(4, 'familyMembersCount')
+
+    expect(wrapper.instance().props.addSurveyData).toHaveBeenCalledTimes(1)
+    expect(wrapper.instance().props.addSurveyData).toHaveBeenCalledWith(
+      4,
+      'familyData',
+      {
+        familyMembersCount: 4
+      }
+    )
+  })
+  it('remove excess family members when count is lowered', () => {
+    wrapper
+      .find('#familyMembersCount')
+      .props()
+      .onChange(1, 'familyMembersCount')
+
+    expect(wrapper.instance().props.removeFamilyMembers).toHaveBeenCalledTimes(
+      1
+    )
+    expect(wrapper.instance().props.removeFamilyMembers).toHaveBeenCalledWith(
+      4,
+      1
+    )
+  })
+  it('shows and hides errors', () => {
+    wrapper.instance().detectError(true, 'test')
+
+    expect(wrapper).toHaveState({ errorsDetected: ['test'] })
+
+    wrapper.instance().detectError(true, 'anotherError')
+
+    expect(wrapper).toHaveState({ errorsDetected: ['test', 'anotherError'] })
+
+    wrapper.instance().detectError(false, 'test')
+
+    expect(wrapper).toHaveState({ errorsDetected: ['anotherError'] })
   })
   it('disables Button when no count is selected', () => {
     const props = createTestProps({

--- a/src/screens/lifemap/FamilyMembersNames.js
+++ b/src/screens/lifemap/FamilyMembersNames.js
@@ -99,6 +99,7 @@ export class FamilyMembersNames extends Component {
       >
         <View style={{ ...globalStyles.container, padding: 0 }}>
           <Select
+            id="familyMembersCount"
             required
             onChange={this.addFamilyCount}
             label="Number of people living in this household"

--- a/src/screens/lifemap/FamilyMembersNames.js
+++ b/src/screens/lifemap/FamilyMembersNames.js
@@ -3,7 +3,11 @@ import { ScrollView, StyleSheet, View } from 'react-native'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 
-import { addSurveyData, addSurveyFamilyMemberData } from '../../redux/actions'
+import {
+  addSurveyData,
+  addSurveyFamilyMemberData,
+  removeFamilyMembers
+} from '../../redux/actions'
 
 import globalStyles from '../../globalStyles'
 import Button from '../../components/Button'
@@ -16,8 +20,8 @@ export class FamilyMembersNames extends Component {
 
   state = { errorsDetected: [] }
 
-  handleClick(draft) {
-    this.getFieldValue(draft, 'countFamilyMembers') > 1
+  handleClick() {
+    this.getFieldValue('countFamilyMembers') > 1
       ? this.props.navigation.navigate('FamilyMembersGender', {
           draftId: this.draftId,
           survey: this.survey
@@ -27,7 +31,11 @@ export class FamilyMembersNames extends Component {
           survey: this.survey
         })
   }
-  getFieldValue = (draft, field) => {
+  getDraft = () =>
+    this.props.drafts.filter(draft => draft.draftId === this.draftId)[0]
+
+  getFieldValue = field => {
+    const draft = this.getDraft()
     if (!draft) {
       return
     }
@@ -45,6 +53,11 @@ export class FamilyMembersNames extends Component {
   }
 
   addFamilyCount = (text, field) => {
+    // if reducing the number of family members remove the rest
+    if (this.getFieldValue('countFamilyMembers') > text) {
+      this.props.removeFamilyMembers(this.draftId, text)
+    }
+
     this.props.addSurveyData(this.draftId, 'familyData', {
       [field]: text
     })
@@ -61,9 +74,7 @@ export class FamilyMembersNames extends Component {
   }
 
   render() {
-    const draft = this.props.drafts.filter(
-      draft => draft.draftId === this.draftId
-    )[0]
+    const draft = this.getDraft()
 
     const emptyRequiredFields =
       draft.familyData.familyMembersList.filter(item => item.firstName === '')
@@ -93,7 +104,7 @@ export class FamilyMembersNames extends Component {
             label="Number of people living in this household"
             placeholder="Number of people living in this household"
             field="countFamilyMembers"
-            value={this.getFieldValue(draft, 'countFamilyMembers') || ''}
+            value={this.getFieldValue('countFamilyMembers') || ''}
             detectError={this.detectError}
             data={Array(10)
               .fill()
@@ -120,7 +131,7 @@ export class FamilyMembersNames extends Component {
               onChangeText={text => this.addFamilyMemberName(text, i + 1)}
               placeholder="Name"
               value={
-                (this.getFieldValue(draft, 'familyMembersList')[i + 1] || {})
+                (this.getFieldValue('familyMembersList')[i + 1] || {})
                   .firstName || ''
               }
               required
@@ -134,7 +145,7 @@ export class FamilyMembersNames extends Component {
             colored
             text="Continue"
             disabled={!isButtonEnabled}
-            handleClick={() => this.handleClick(draft)}
+            handleClick={() => this.handleClick()}
           />
         </View>
       </ScrollView>
@@ -153,12 +164,14 @@ FamilyMembersNames.propTypes = {
   drafts: PropTypes.array,
   navigation: PropTypes.object.isRequired,
   addSurveyData: PropTypes.func.isRequired,
-  addSurveyFamilyMemberData: PropTypes.func.isRequired
+  addSurveyFamilyMemberData: PropTypes.func.isRequired,
+  removeFamilyMembers: PropTypes.func.isRequired
 }
 
 const mapDispatchToProps = {
   addSurveyData,
-  addSurveyFamilyMemberData
+  addSurveyFamilyMemberData,
+  removeFamilyMembers
 }
 
 const mapStateToProps = ({ drafts }) => ({


### PR DESCRIPTION
This is related to the following issues: #118 and #76.

Make sure the status bar elements like battery status are visible compared to the background (no need to check colors). Follow the instructions in #118 and see if when reducing family members count, the excess family members are deleted.