### PR TITLE
Set proper topics to socio economic questions

### DIFF
--- a/src/components/navigation/LifemapScreens.js
+++ b/src/components/navigation/LifemapScreens.js
@@ -41,7 +41,6 @@ export default {
   SocioEconomicQuestion: {
     screen: SocioEconomicQuestionView,
     navigationOptions: ({ navigation }) => ({
-      title: i18n.t('views.socioEconomic'),
       ...generateNavOptions({ navigation, burgerMenu: false })
     })
   },

--- a/src/redux/__tests__/actions.test.js
+++ b/src/redux/__tests__/actions.test.js
@@ -119,7 +119,7 @@ describe('surveys actions', () => {
             headers: { Authorization: `Bearer ${token}` },
             body: JSON.stringify({
               query:
-                'query { surveysByUser { title id minimumPriorities surveyConfig { documentType {text value} gender { text value}}  surveyEconomicQuestions { questionText codeName answerType  required forFamilyMember options {text value} } surveyStoplightQuestions { questionText codeName dimension id stoplightColors { url value description } required } } }'
+                'query { surveysByUser { title id minimumPriorities surveyConfig { documentType {text value} gender { text value}}  surveyEconomicQuestions { questionText codeName answerType topic required forFamilyMember options {text value} } surveyStoplightQuestions { questionText codeName dimension id stoplightColors { url value description } required } } }'
             })
           },
           commit: { type: action.LOAD_SURVEYS }

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -63,7 +63,7 @@ export const loadSurveys = (env, token) => ({
         headers: { Authorization: `Bearer ${token}` },
         body: JSON.stringify({
           query:
-            'query { surveysByUser { title id minimumPriorities surveyConfig { documentType {text value} gender { text value}}  surveyEconomicQuestions { questionText codeName answerType  required forFamilyMember options {text value} } surveyStoplightQuestions { questionText codeName dimension id stoplightColors { url value description } required } } }'
+            'query { surveysByUser { title id minimumPriorities surveyConfig { documentType {text value} gender { text value}}  surveyEconomicQuestions { questionText codeName answerType topic required forFamilyMember options {text value} } surveyStoplightQuestions { questionText codeName dimension id stoplightColors { url value description } required } } }'
         })
       },
       commit: { type: LOAD_SURVEYS }

--- a/src/screens/__tests__/SocioEconomicQuestion.test.js
+++ b/src/screens/__tests__/SocioEconomicQuestion.test.js
@@ -181,7 +181,18 @@ describe('SocioEconomicQuestion screens', () => {
                           options: []
                         }
                       ],
-                      forFamily: []
+                      forFamily: [
+                        {
+                          questionText:
+                            'Please estimate your gross monthly household income (i.e, before taxes National Insurance contributions or other deductions)',
+                          answerType: 'text',
+                          dimension: 'Income',
+                          required: true,
+                          codeName: '3',
+                          forFamilyMember: false,
+                          options: []
+                        }
+                      ]
                     }
                   ]
                 }
@@ -193,7 +204,7 @@ describe('SocioEconomicQuestion screens', () => {
     })
 
     it('renders a TextInput for each text question for each family member', () => {
-      expect(wrapper.find(TextInput)).toHaveLength(2)
+      expect(wrapper.find(TextInput)).toHaveLength(3)
     })
 
     it('sets the correct TextInput props', () => {

--- a/src/screens/lifemap/SocioEconomicQuestion.js
+++ b/src/screens/lifemap/SocioEconomicQuestion.js
@@ -11,6 +11,12 @@ import globalStyles from '../../globalStyles'
 import { addSurveyData, addSurveyFamilyMemberData } from '../../redux/actions'
 
 export class SocioEconomicQuestion extends Component {
+  static navigationOptions = ({ navigation }) => {
+    return {
+      title: navigation.getParam('title')
+    }
+  }
+
   errorsDetected = []
 
   state = { errorsDetected: [] }
@@ -31,8 +37,8 @@ export class SocioEconomicQuestion extends Component {
         .getParam('survey')
         .surveyEconomicQuestions.forEach(question => {
           // if the dimention of the questions change, change the page
-          if (question.dimension !== currentDimension) {
-            currentDimension = question.dimension
+          if (question.topic !== currentDimension) {
+            currentDimension = question.topic
             totalScreens += 1
           }
 
@@ -50,13 +56,26 @@ export class SocioEconomicQuestion extends Component {
             questionsPerScreen[totalScreens - 1].forFamily.push(question)
           }
         })
-
       props.navigation.setParams({
         socioEconomics: {
           currentScreen: 1,
           questionsPerScreen,
           totalScreens
-        }
+        },
+        title: questionsPerScreen[0].forFamily[0]
+          ? questionsPerScreen[0].forFamily[0].topic
+          : questionsPerScreen[0].forFamilyMemver[0].topic
+      })
+    } else {
+      const socioEconomics = this.props.navigation.getParam('socioEconomics')
+      const questionsForThisScreen = socioEconomics
+        ? socioEconomics.questionsPerScreen[socioEconomics.currentScreen - 1]
+        : []
+
+      this.props.navigation.setParams({
+        title: questionsForThisScreen.forFamily[0]
+          ? questionsForThisScreen.forFamily[0].topic
+          : questionsForThisScreen.forFamilyMemver[0].topic
       })
     }
   }
@@ -116,7 +135,6 @@ export class SocioEconomicQuestion extends Component {
       errorsDetected: this.errorsDetected
     })
   }
-
   render() {
     const { t } = this.props
     const draft = this.props.drafts.filter(
@@ -141,31 +159,30 @@ export class SocioEconomicQuestion extends Component {
         >
           {/* questions for entire family */}
           {socioEconomics ? (
-            questionsForThisScreen.forFamily.map(
-              question =>
-                question.answerType === 'select' ? (
-                  <Select
-                    key={question.codeName}
-                    required={question.required}
-                    onChange={this.addSurveyData}
-                    placeholder={question.questionText}
-                    label={question.questionText}
-                    field={question.codeName}
-                    value={this.getFieldValue(draft, question.codeName) || ''}
-                    detectError={this.detectError}
-                    data={question.options}
-                  />
-                ) : (
-                  <TextInput
-                    key={question.codeName}
-                    required={question.required}
-                    onChangeText={this.addSurveyData}
-                    placeholder={question.questionText}
-                    field={question.codeName}
-                    value={this.getFieldValue(draft, question.codeName) || ''}
-                    detectError={this.detectError}
-                  />
-                )
+            questionsForThisScreen.forFamily.map(question =>
+              question.answerType === 'select' ? (
+                <Select
+                  key={question.codeName}
+                  required={question.required}
+                  onChange={this.addSurveyData}
+                  placeholder={question.questionText}
+                  label={question.questionText}
+                  field={question.codeName}
+                  value={this.getFieldValue(draft, question.codeName) || ''}
+                  detectError={this.detectError}
+                  data={question.options}
+                />
+              ) : (
+                <TextInput
+                  key={question.codeName}
+                  required={question.required}
+                  onChangeText={this.addSurveyData}
+                  placeholder={question.questionText}
+                  field={question.codeName}
+                  value={this.getFieldValue(draft, question.codeName) || ''}
+                  detectError={this.detectError}
+                />
+              )
             )
           ) : (
             <View />
@@ -177,47 +194,46 @@ export class SocioEconomicQuestion extends Component {
               draft.familyData.familyMembersList.map((member, i) => (
                 <View key={member.firstName}>
                   <Text style={styles.memberName}>{member.firstName}</Text>
-                  {questionsForThisScreen.forFamilyMember.map(
-                    question =>
-                      question.answerType === 'select' ? (
-                        <Select
-                          key={question.codeName}
-                          required={question.required}
-                          onChange={(text, field) =>
-                            this.addSurveyFamilyMemberData(text, field, i)
-                          }
-                          placeholder={question.questionText}
-                          label={question.questionText}
-                          field={question.codeName}
-                          value={
-                            this.getFamilyMemberFieldValue(
-                              draft,
-                              question.codeName,
-                              i
-                            ) || ''
-                          }
-                          detectError={this.detectError}
-                          data={question.options}
-                        />
-                      ) : (
-                        <TextInput
-                          key={question.codeName}
-                          required={question.required}
-                          onChangeText={(text, field) =>
-                            this.addSurveyFamilyMemberData(text, field, i)
-                          }
-                          placeholder={question.questionText}
-                          field={question.codeName}
-                          value={
-                            this.getFamilyMemberFieldValue(
-                              draft,
-                              question.codeName,
-                              i
-                            ) || ''
-                          }
-                          detectError={this.detectError}
-                        />
-                      )
+                  {questionsForThisScreen.forFamilyMember.map(question =>
+                    question.answerType === 'select' ? (
+                      <Select
+                        key={question.codeName}
+                        required={question.required}
+                        onChange={(text, field) =>
+                          this.addSurveyFamilyMemberData(text, field, i)
+                        }
+                        placeholder={question.questionText}
+                        label={question.questionText}
+                        field={question.codeName}
+                        value={
+                          this.getFamilyMemberFieldValue(
+                            draft,
+                            question.codeName,
+                            i
+                          ) || ''
+                        }
+                        detectError={this.detectError}
+                        data={question.options}
+                      />
+                    ) : (
+                      <TextInput
+                        key={question.codeName}
+                        required={question.required}
+                        onChangeText={(text, field) =>
+                          this.addSurveyFamilyMemberData(text, field, i)
+                        }
+                        placeholder={question.questionText}
+                        field={question.codeName}
+                        value={
+                          this.getFamilyMemberFieldValue(
+                            draft,
+                            question.codeName,
+                            i
+                          ) || ''
+                        }
+                        detectError={this.detectError}
+                      />
+                    )
                   )}
                 </View>
               ))


### PR DESCRIPTION
The socio economic questions should be grouped by topic and they are not. This is the result of a name change of the `dimension` prop to `topic`. I've also set the nav title to the current topic.

**To Test**
1. Make a new life map and go to socio-economic questions
2. The title should be the topic of the current screen
3. Taping continue leads you to the next screen
