### PR TITLE
Responsive images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "PovertyStoplightApp",
-  "version": "1.0.0",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10253,6 +10253,11 @@
         "opencollective": "^1.0.3",
         "prop-types": "^15.5.8"
       }
+    },
+    "react-native-fullwidth-image": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/react-native-fullwidth-image/-/react-native-fullwidth-image-0.1.2.tgz",
+      "integrity": "sha512-W9dlWPta7QcJnn0SO7VH6MCA+f47nd48aYUsb7bCKOYmSM46cS2D/W9V3nkS06Kung8Y2uNVTuyH0ochaTLnaw=="
     },
     "react-native-languages": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-native-background-fetch": "^2.4.4",
     "react-native-background-task": "^0.2.1",
     "react-native-elements": "^0.19.1",
+    "react-native-fullwidth-image": "^0.1.2",
     "react-native-languages": "^3.0.1",
     "react-native-maps": "^0.22.1",
     "react-native-sentry": "^0.39.1",

--- a/src/components/CachedImage.js
+++ b/src/components/CachedImage.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
-import { Image, Platform } from 'react-native'
+import { Platform } from 'react-native'
+import FullWidthImage from 'react-native-fullwidth-image'
 import PropTypes from 'prop-types'
 import RNFetchBlob from 'rn-fetch-blob'
 
@@ -14,9 +15,10 @@ export class CachedImage extends Component {
     const { style, source } = this.props
 
     return (
-      <Image
+      <FullWidthImage
         style={style}
         resizeMode="cover"
+        ratio={1}
         source={{
           uri: this.getProperSourceForOS(
             `${dirs.DocumentDir}/${source.replace(/https?:\/\//, '')}`

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -13,7 +13,7 @@ import colors from '../theme.json'
 import globalStyles from '../globalStyles'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import { connect } from 'react-redux'
-import { isTablet, isPortrait } from '../responsivenessHelpers'
+import { isPortrait } from '../responsivenessHelpers'
 const slideColors = {
   1: 'red',
   2: 'gold',
@@ -95,12 +95,7 @@ export class Slider extends Component {
                 <Image
                   source={slide.url}
                   style={{
-                    ...styles.image,
-                    height: isPortrait(dimensions)
-                      ? isTablet(dimensions)
-                        ? height / 2
-                        : height / 3
-                      : height / 4
+                    ...styles.image
                   }}
                 />
                 <Text

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -98,6 +98,19 @@ export class Slider extends Component {
                     ...styles.image
                   }}
                 />
+                {this.props.value === slide.value ? (
+                  <View
+                    id="icon-view"
+                    style={{
+                      ...styles.iconBig,
+                      backgroundColor: colors[slideColors[this.props.value]]
+                    }}
+                  >
+                    <Icon name="done" size={56} color={colors.white} />
+                  </View>
+                ) : (
+                  <View />
+                )}
                 <Text
                   style={{
                     ...globalStyles.p,
@@ -108,23 +121,6 @@ export class Slider extends Component {
                   {slide.description}
                 </Text>
               </TouchableOpacity>
-            </View>
-          ))}
-          {this.props.slides.map((slide, i) => (
-            <View style={{ width: '33%', marginTop: -40 }} key={i}>
-              {this.props.value === slide.value ? (
-                <View
-                  id="icon-view"
-                  style={{
-                    ...styles.iconBig,
-                    backgroundColor: colors[slideColors[this.props.value]]
-                  }}
-                >
-                  <Icon name="done" size={56} color={colors.white} />
-                </View>
-              ) : (
-                <View />
-              )}
             </View>
           ))}
         </ScrollView>
@@ -146,12 +142,11 @@ const styles = StyleSheet.create({
   text: {
     color: colors.white,
     textAlign: 'center',
-    padding: 15,
-    paddingBottom: 45
+    padding: 15
   },
   image: {
     width: '100%',
-    marginTop: 15
+    marginTop: 10
   },
   iconBig: {
     borderRadius: 40,
@@ -160,8 +155,8 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     alignSelf: 'center',
-    borderColor: colors.white,
-    borderWidth: 3
+    marginTop: -50,
+    marginBottom: -20
   }
 })
 

--- a/src/components/__tests__/CachedImage.test.js
+++ b/src/components/__tests__/CachedImage.test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { Image, Platform } from 'react-native'
+import { Platform } from 'react-native'
+import FullWidthImage from 'react-native-fullwidth-image'
 import { CachedImage } from '../CachedImage'
 
 const createTestProps = props => ({
@@ -24,14 +25,14 @@ describe('CachedImage', () => {
     })
 
     it('renders <Image />', () => {
-      expect(wrapper.find(Image)).toHaveLength(1)
+      expect(wrapper.find(FullWidthImage)).toHaveLength(1)
     })
 
     it('sets proper source based on OS', () => {
       expect(wrapper.instance().getProperSourceForOS('some.url.png')).toEqual(
         Platform.OS === 'android' ? 'file://some.url.png' : 'some.url.png'
       )
-      expect(wrapper.find(Image)).toHaveProp('source', {
+      expect(wrapper.find(FullWidthImage)).toHaveProp('source', {
         uri:
           Platform.OS === 'android' ? 'file://some.url.png' : 'foo/some.url.png'
       })

--- a/src/screens/__tests__/Question.test.js
+++ b/src/screens/__tests__/Question.test.js
@@ -95,7 +95,11 @@ const survey = {
   id: 1,
   title: 'Test survey 1',
   surveyStoplightQuestions: [
-    { stoplightColors: [{ codeName: 'phoneNumber' }], required: false }
+    {
+      stoplightColors: [{ codeName: 'phoneNumber' }],
+      required: false,
+      dimension: 'Dimension'
+    }
   ]
 }
 

--- a/src/screens/lifemap/Question.js
+++ b/src/screens/lifemap/Question.js
@@ -91,10 +91,11 @@ export class Question extends Component {
     const { t } = this.props
     return (
       <ScrollView style={globalStyles.background}>
-        <View style={{ ...globalStyles.container, paddingTop: 20 }}>
-          <Text style={{ ...globalStyles.h5, textAlign: 'right' }}>{`${this
-            .step + 1} / ${this.indicators.length}`}</Text>
-          <Text style={{ ...globalStyles.h3 }}>{`${this.step + 1}. ${
+        <View style={{ ...globalStyles.container, paddingTop: 15 }}>
+          <Text style={{ ...globalStyles.h5 }}>
+            {this.indicator.dimension.toUpperCase()}
+          </Text>
+          <Text style={{ ...globalStyles.h3, marginTop: 5 }}>{`${
             this.indicator.questionText
           }`}</Text>
           <ProgressBarAndroid
@@ -102,7 +103,7 @@ export class Question extends Component {
             color={colors.green}
             indeterminate={false}
             progress={(this.step + 1) / this.indicators.length}
-            style={{ marginTop: 35 }}
+            style={{ marginTop: 5, marginBottom: -15 }}
           />
         </View>
         <Slider


### PR DESCRIPTION
**Describe the changes**
Images for the stoplight questions are now changed according to the design.
Check sign is moved. Images are square. The question number is deleted. Spacing is edited to fit the screen.

![image](https://user-images.githubusercontent.com/25869467/50697302-88304580-104a-11e9-9aab-28769ab3de54.png)

**Related issues**
- Resolves #175
