### PR TITLE
Fix image syncing after log out

### DIFF
--- a/src/screens/Loading.js
+++ b/src/screens/Loading.js
@@ -24,7 +24,6 @@ export class Loading extends Component {
   checkHydrationTimer
   state = {
     loadingData: false, // know when to show that data is synced
-    querriesAreMade: false, // know when actual querries are made, not the same as above
     cachingImages: false
   }
   clearTimers = () => {
@@ -36,9 +35,6 @@ export class Loading extends Component {
       loadingData: true
     })
     this.props.loadSurveys(url[this.props.env], this.props.user.token)
-    this.setState({
-      querriesAreMade: true
-    })
   }
   checkHydration = () => {
     if (getHydrationState() === false) {
@@ -63,7 +59,7 @@ export class Loading extends Component {
     const { total, synced } = this.props.sync.images
 
     if (
-      this.state.querriesAreMade &&
+      this.props.surveys.length &&
       !this.props.offline.outbox.lenght &&
       !this.state.cachingImages
     ) {


### PR DESCRIPTION
There is a timing error in the Loading component after logout and re-logging in. The image sync begins before there are actual surveys to download the images of. This pull request attempts to fix that.

**To Test**
1. At a state of being logged in and having all images synced, log out.
2. Log in with the same user.
3. The loading screen should show images syncing after surveys have done so. There might be a short delay between the two, but images should start syncing within 3-4 secs.
4. After logged in again log out.
5. Log in with a different user and observe step 3.

**Related issues**
- Resolves #242
