### PR TITLE
Make achievements first question and priorities months mandatory

### DIFF
--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -123,18 +123,22 @@ class TextInput extends Component {
 
     return (
       <View style={{ marginBottom: 15 }}>
-        {label && <Text style={styles.label}>{label}</Text>}
+        {label && (
+          <Text style={styles.label}>{`${label}${required ? ' *' : ''}`}</Text>
+        )}
         <View style={[styles.container, styles[status]]}>
-          {!showPlaceholder && (
+          {!showPlaceholder && !label ? (
             <Text
               style={{
                 ...styles.text,
                 color: this.defineTextColor(status)
               }}
             >
-              {`${placeholder} ${required ? '*' : ''}`}
+              {`${placeholder} ${required && !label ? '*' : ''}`}
               {'\n'}
             </Text>
+          ) : (
+            <View />
           )}
           <FormInput
             keyboardType={this.props.keyboardType}
@@ -144,7 +148,9 @@ class TextInput extends Component {
             onChangeText={text => this.onChangeText(text)}
             onEndEditing={this.onEndEditing}
             placeholder={
-              showPlaceholder ? `${placeholder} ${required ? '*' : ''}` : ''
+              showPlaceholder
+                ? `${placeholder} ${required && !label ? '*' : ''}`
+                : ''
             }
             inputStyle={[
               styles.inputStyle,

--- a/src/screens/__tests__/AddAchievement.test.js
+++ b/src/screens/__tests__/AddAchievement.test.js
@@ -51,6 +51,7 @@ describe('AddAchievement View', () => {
   describe('functionality', () => {
     it('has correct initial state', () => {
       expect(wrapper.instance().state).toEqual({
+        errorsDetected: [],
         action: '',
         roadmap: '',
         indicator: 'income'

--- a/src/screens/__tests__/AddAchievement.test.js
+++ b/src/screens/__tests__/AddAchievement.test.js
@@ -46,6 +46,10 @@ describe('AddAchievement View', () => {
     it('renders Button', () => {
       expect(wrapper.find(Button)).toHaveLength(1)
     })
+    it('Save button is disabled if errors detected', () => {
+      wrapper.instance().errorsDetected = ['test']
+      expect(wrapper.find('#save')).toHaveProp('disabled')
+    })
   })
 
   describe('functionality', () => {

--- a/src/screens/__tests__/AddPriority.test.js
+++ b/src/screens/__tests__/AddPriority.test.js
@@ -55,10 +55,11 @@ describe('AddPriority View', () => {
   describe('functionality', () => {
     it('has correct initial state', () => {
       expect(wrapper.instance().state).toEqual({
-        reason: '',
         action: '',
+        estimatedDate: 0,
         indicator: 'income',
-        estimatedDate: 0
+        reason: '',
+        validationError: false
       })
     })
     it('increases count correctly', () => {
@@ -99,7 +100,19 @@ describe('AddPriority View', () => {
         .onChangeText('Some action')
       expect(wrapper.instance().state.action).toEqual('Some action')
     })
-    it('saves the priority', () => {
+    it('doesn\'t save the priority if no months entered', () => {
+      wrapper
+        .find(Button)
+        .props()
+        .handleClick()
+
+      expect(
+        wrapper.instance().props.addSurveyPriorityAcheivementData
+      ).toHaveBeenCalledTimes(0)
+    })
+    it('saves the priority if valid', () => {
+      wrapper.instance().setState({ estimatedDate: 2 })
+
       wrapper
         .find(Button)
         .props()

--- a/src/screens/lifemap/AddAchievement.js
+++ b/src/screens/lifemap/AddAchievement.js
@@ -124,6 +124,7 @@ export class AddAchievement extends Component {
         </View>
         <View style={{ height: 50 }}>
           <Button
+            id="save"
             colored
             disabled={!!this.errorsDetected.length}
             text={t('general.save')}

--- a/src/screens/lifemap/AddAchievement.js
+++ b/src/screens/lifemap/AddAchievement.js
@@ -14,10 +14,24 @@ import Button from '../../components/Button'
 import TextInput from '../../components/TextInput'
 
 export class AddAchievement extends Component {
+  errorsDetected = []
   state = {
     action: '',
     roadmap: '',
+    errorsDetected: [],
     indicator: this.props.navigation.getParam('indicator')
+  }
+
+  detectError = (error, field) => {
+    if (error && !this.errorsDetected.includes(field)) {
+      this.errorsDetected.push(field)
+    } else if (!error) {
+      this.errorsDetected = this.errorsDetected.filter(item => item !== field)
+    }
+
+    this.setState({
+      errorsDetected: this.errorsDetected
+    })
   }
 
   componentDidMount() {
@@ -87,7 +101,9 @@ export class AddAchievement extends Component {
             </View>
           </View>
           <TextInput
-            field=""
+            field="action"
+            required
+            detectError={this.detectError}
             onChangeText={text => this.setState({ action: text })}
             placeholder={
               this.state.action ? '' : t('views.lifemap.writeYourAnswerHere')
@@ -109,6 +125,7 @@ export class AddAchievement extends Component {
         <View style={{ height: 50 }}>
           <Button
             colored
+            disabled={!!this.errorsDetected.length}
             text={t('general.save')}
             handleClick={() => this.addAchievement()}
           />

--- a/src/screens/lifemap/AddPriority.js
+++ b/src/screens/lifemap/AddPriority.js
@@ -18,6 +18,7 @@ export class AddPriority extends Component {
     reason: '',
     action: '',
     estimatedDate: 0,
+    validationError: false,
     indicator: this.props.navigation.getParam('indicator')
   }
 
@@ -26,6 +27,9 @@ export class AddPriority extends Component {
   }
 
   editCounter = action => {
+    this.setState({
+      validationError: false
+    })
     if (action === 'minus' && this.state.estimatedDate > 0) {
       return this.setState({ estimatedDate: this.state.estimatedDate - 1 })
     } else if (action === 'plus') {
@@ -46,12 +50,18 @@ export class AddPriority extends Component {
     )[0]
 
   addPriority = () => {
-    this.props.addSurveyPriorityAcheivementData({
-      id: this.props.navigation.getParam('draftId'),
-      category: 'priorities',
-      payload: this.state
-    })
-    this.props.navigation.goBack()
+    if (!this.state.estimatedDate) {
+      this.setState({
+        validationError: true
+      })
+    } else {
+      this.props.addSurveyPriorityAcheivementData({
+        id: this.props.navigation.getParam('draftId'),
+        category: 'priorities',
+        payload: this.state
+      })
+      this.props.navigation.goBack()
+    }
   }
 
   getPriorityValue = draft => {
@@ -64,6 +74,7 @@ export class AddPriority extends Component {
 
   render() {
     const { t } = this.props
+    const { validationError, reason, action, estimatedDate } = this.state
     const draft = this.getDraft()
     const priority = this.getPriorityValue(draft)
 
@@ -96,9 +107,7 @@ export class AddPriority extends Component {
           </View>
           <TextInput
             onChangeText={text => this.setState({ reason: text })}
-            placeholder={
-              this.state.reason ? '' : t('views.lifemap.writeYourAnswerHere')
-            }
+            placeholder={reason ? '' : t('views.lifemap.writeYourAnswerHere')}
             label={t('views.lifemap.whyDontYouHaveIt')}
             value={priority ? priority.reason : ''}
             multiline
@@ -106,19 +115,25 @@ export class AddPriority extends Component {
           <TextInput
             label={t('views.lifemap.whatWillYouDoToGetIt')}
             onChangeText={text => this.setState({ action: text })}
-            placeholder={
-              this.state.action ? '' : t('views.lifemap.writeYourAnswerHere')
-            }
+            placeholder={action ? '' : t('views.lifemap.writeYourAnswerHere')}
             value={priority ? priority.action : ''}
             multiline
           />
           <View style={{ padding: 15 }}>
             <Counter
               editCounter={this.editCounter}
-              count={this.state.estimatedDate}
+              count={estimatedDate}
               text={t('views.lifemap.howManyMonthsWillItTake')}
             />
           </View>
+          {/* Error message */}
+          {validationError ? (
+            <Text style={{ paddingHorizontal: 15, color: colors.red }}>
+              {t('validation.fieldIsRequired')}
+            </Text>
+          ) : (
+            <View />
+          )}
         </View>
         <View style={{ height: 50 }}>
           <Button


### PR DESCRIPTION
The “how many months will it take” question in priorities and the first question of achievements are now mandatory. I've also found another Text Input related issue described in #198.

**To Test**
Specific steps to test when reviewing:
1. Go to Overview screen in any draft that has both green and either yellow or red answers.
2. Tap on any green answer.
3. Make sure the first question has a * required mark next to the label above (not the placeholder inside the field.
4. Make sure the save button is disabled
5. Enter some text in that field. The placeholder should be gone and only the label and text should appear. The save button should be enabled.
6. Make sure the data is saved.
7. Tap on any yellow or red answer.
8. Save button is enabled.
9. With 0 months selected, taping Save will instead show a required field error below the Months field.
