### PR TITLE
Fix saving validation error to draft

### DIFF
--- a/src/screens/lifemap/AddAchievement.js
+++ b/src/screens/lifemap/AddAchievement.js
@@ -50,10 +50,11 @@ export class AddAchievement extends Component {
     )[0]
 
   addAchievement = () => {
+    const { action, roadmap, indicator } = this.state
     this.props.addSurveyPriorityAcheivementData({
       id: this.props.navigation.getParam('draftId'),
       category: 'achievements',
-      payload: this.state
+      payload: { action, roadmap, indicator }
     })
     this.props.navigation.goBack()
   }

--- a/src/screens/lifemap/AddPriority.js
+++ b/src/screens/lifemap/AddPriority.js
@@ -55,10 +55,11 @@ export class AddPriority extends Component {
         validationError: true
       })
     } else {
+      const { reason, action, estimatedDate, indicator } = this.state
       this.props.addSurveyPriorityAcheivementData({
         id: this.props.navigation.getParam('draftId'),
         category: 'priorities',
-        payload: this.state
+        payload: { reason, action, estimatedDate, indicator }
       })
       this.props.navigation.goBack()
     }


### PR DESCRIPTION
As adding a priority sends the whole state to the draft, I've removed validation error from the lot.

**To Test**
Specific steps to test when reviewing:
1. Go to any draft's overview screen
2. Tap on a red or yellow question
3. Fill all the date and tap save
4. No prop `validationError` should be save to the draft

No related issue. This is a quickfix.
