### PR TITLE
Form validation

### DIFF
--- a/src/components/DateInput.js
+++ b/src/components/DateInput.js
@@ -86,6 +86,12 @@ export class DateInput extends React.Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.showErrors !== this.props.showErrors) {
+      this.validateDate(this.props.value || '')
+    }
+  }
+
   render() {
     const { t } = this.props
     const validDate =
@@ -179,6 +185,7 @@ DateInput.propTypes = {
   t: PropTypes.func.isRequired,
   field: PropTypes.string,
   required: PropTypes.bool,
+  showErrors: PropTypes.bool,
   detectError: PropTypes.func,
   onValidDate: PropTypes.func
 }

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -64,7 +64,7 @@ class Select extends Component {
 
   componentDidUpdate(prevProps) {
     if (prevProps.showErrors !== this.props.showErrors) {
-      this.validateInput(this.props.value)
+      this.validateInput(this.props.value || '')
     }
   }
 

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -62,6 +62,12 @@ class Select extends Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.showErrors !== this.props.showErrors) {
+      this.validateInput(this.props.value)
+    }
+  }
+
   render() {
     const { errorMsg, isOpen } = this.state
     const { value, placeholder, required, options, countrySelect } = this.props
@@ -88,8 +94,6 @@ class Select extends Component {
     } else {
       text = ''
     }
-
-    console.log(placeholder)
 
     return (
       <TouchableOpacity onPress={this.toggleDropdown}>
@@ -207,6 +211,7 @@ Select.propTypes = {
   field: PropTypes.string,
   country: PropTypes.string,
   countrySelect: PropTypes.bool,
+  showErrors: PropTypes.bool,
   required: PropTypes.bool,
   detectError: PropTypes.func
 }

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -44,7 +44,7 @@ class Select extends Component {
     if (this.props.required && !value) {
       this.handleError(i18n.t('validation.fieldIsRequired'))
       this.setState({
-        errorMsg: 'This field is required'
+        errorMsg: i18n.t('validation.fieldIsRequired')
       })
     } else {
       this.props.onChange(value, this.props.field)
@@ -111,13 +111,18 @@ class Select extends Component {
                 style={[
                   styles.title,
                   isOpen &&
-                    !errorMsg && {
+                  !errorMsg && {
                       color: colors.green
-                    }
+                  }
                 ]}
               >{`${placeholder}${required ? ' *' : ''}`}</Text>
             )}
-            <Text style={[styles.placeholder]}>
+            <Text
+              style={[
+                styles.placeholder,
+                errorMsg ? { color: colors.red } : {}
+              ]}
+            >
               {value ? text : `${placeholder}${required ? ' *' : ''}`}
             </Text>
             <Image source={arrow} style={styles.arrow} />

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -114,6 +114,12 @@ class TextInput extends Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.showErrors !== this.props.showErrors) {
+      this.validateInput(this.props.value)
+    }
+  }
+
   render() {
     const { text, errorMsg } = this.state
     const { label, placeholder, required, readonly, multiline } = this.props
@@ -229,6 +235,7 @@ TextInput.propTypes = {
   readonly: PropTypes.bool,
   onChangeText: PropTypes.func.isRequired,
   multiline: PropTypes.bool,
+  showErrors: PropTypes.bool,
   keyboardType: PropTypes.string,
   validation: PropTypes.oneOf([
     'email',

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { View, Text, StyleSheet } from 'react-native'
-import { FormInput, FormValidationMessage } from 'react-native-elements'
+import { FormInput } from 'react-native-elements'
 import colors from '../theme.json'
 import validator from 'validator'
 import globalStyles from '../globalStyles'
@@ -166,9 +166,9 @@ class TextInput extends Component {
           </FormInput>
         </View>
         {status === 'error' && errorMsg ? (
-          <FormValidationMessage style={{ color: colors.red }}>
+          <Text style={{ paddingHorizontal: 15, color: colors.red }}>
             {errorMsg}
-          </FormValidationMessage>
+          </Text>
         ) : (
           <View />
         )}

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -116,7 +116,7 @@ class TextInput extends Component {
 
   componentDidUpdate(prevProps) {
     if (prevProps.showErrors !== this.props.showErrors) {
-      this.validateInput(this.props.value)
+      this.validateInput(this.props.value || '')
     }
   }
 

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -161,7 +161,9 @@ class TextInput extends Component {
             multiline={multiline}
           >
             <Text style={styles.inputText}>
-              {showPlaceholder ? placeholder : text}
+              {showPlaceholder
+                ? `${placeholder} ${required && !label ? '*' : ''}`
+                : text}
             </Text>
           </FormInput>
         </View>

--- a/src/components/__tests__/Select.test.js
+++ b/src/components/__tests__/Select.test.js
@@ -119,4 +119,13 @@ describe('Select dropdown', () => {
     expect(spy).toHaveBeenCalledTimes(1)
     expect(spy).toHaveBeenCalledWith(2)
   })
+
+  it('shows required error message when parent form is submitted', () => {
+    props = createTestProps({ required: true, validation: 'string' })
+    wrapper = shallow(<Select {...props} />)
+
+    wrapper.setProps({ showErrors: true })
+
+    expect(wrapper).toHaveState({ errorMsg: 'This field is required' })
+  })
 })

--- a/src/components/__tests__/TextInput.test.js
+++ b/src/components/__tests__/TextInput.test.js
@@ -109,6 +109,20 @@ describe('TextInput Component', () => {
     })
   })
 
+  it('shows required error message when parent form is submitted', () => {
+    props = createTestProps({ required: true, validation: 'string' })
+    wrapper = shallow(<TextInput {...props} />)
+
+    wrapper.setProps({ showErrors: true })
+
+    expect(
+      wrapper
+        .find(FormValidationMessage)
+        .render()
+        .text()
+    ).toBe('This field is required')
+  })
+
   it('shows correct error message when validation is email', () => {
     props = createTestProps({ required: true, validation: 'email' })
     wrapper = shallow(<TextInput {...props} />)

--- a/src/components/__tests__/TextInput.test.js
+++ b/src/components/__tests__/TextInput.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { Text } from 'react-native'
-import { FormInput, FormValidationMessage } from 'react-native-elements'
+import { FormInput } from 'react-native-elements'
 
 import TextInput from '../TextInput'
 
@@ -28,9 +28,10 @@ describe('TextInput Component', () => {
     it('renders Text', () => {
       expect(wrapper.find(Text)).toHaveLength(2)
     })
-    it('renders FormValidationMessage when there is an error', () => {
+    it('renders error message when there is an error', () => {
+      expect(wrapper.find(Text)).toHaveLength(2)
       wrapper.setState({ status: 'error', errorMsg: 'error' })
-      expect(wrapper.find(FormValidationMessage)).toHaveLength(1)
+      expect(wrapper.find(Text)).toHaveLength(3)
     })
   })
   describe('functionality', () => {
@@ -102,7 +103,8 @@ describe('TextInput Component', () => {
 
       expect(
         wrapper
-          .find(FormValidationMessage)
+          .find(Text)
+          .last()
           .render()
           .text()
       ).toBe('This field is required')
@@ -117,7 +119,8 @@ describe('TextInput Component', () => {
 
     expect(
       wrapper
-        .find(FormValidationMessage)
+        .find(Text)
+        .last()
         .render()
         .text()
     ).toBe('This field is required')
@@ -135,7 +138,8 @@ describe('TextInput Component', () => {
 
     expect(
       wrapper
-        .find(FormValidationMessage)
+        .find(Text)
+        .last()
         .render()
         .text()
     ).toBe('Please enter a valid email address')
@@ -153,7 +157,8 @@ describe('TextInput Component', () => {
 
     expect(
       wrapper
-        .find(FormValidationMessage)
+        .find(Text)
+        .last()
         .render()
         .text()
     ).toBe('Please enter a valid phone number')
@@ -171,7 +176,8 @@ describe('TextInput Component', () => {
 
     expect(
       wrapper
-        .find(FormValidationMessage)
+        .find(Text)
+        .last()
         .render()
         .text()
     ).toBe('Please enter a valid number')

--- a/src/screens/__tests__/AddAchievement.test.js
+++ b/src/screens/__tests__/AddAchievement.test.js
@@ -46,10 +46,6 @@ describe('AddAchievement View', () => {
     it('renders Button', () => {
       expect(wrapper.find(Button)).toHaveLength(1)
     })
-    it('Save button is disabled if errors detected', () => {
-      wrapper.instance().errorsDetected = ['test']
-      expect(wrapper.find('#save')).toHaveProp('disabled')
-    })
   })
 
   describe('functionality', () => {
@@ -58,6 +54,7 @@ describe('AddAchievement View', () => {
         errorsDetected: [],
         action: '',
         roadmap: '',
+        showErrors: false,
         indicator: 'income'
       })
     })

--- a/src/screens/__tests__/FamilyMembersNames.test.js
+++ b/src/screens/__tests__/FamilyMembersNames.test.js
@@ -139,14 +139,6 @@ describe('FamilyMembersNames View', () => {
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
-  it('enables Button when all fields are filled', () => {
-    expect(
-      wrapper
-        .find(Button)
-        .last()
-        .props().disabled
-    ).toBe(false)
-  })
   it('changes family members count', () => {
     wrapper
       .find('#familyMembersCount')
@@ -188,71 +180,6 @@ describe('FamilyMembersNames View', () => {
     wrapper.instance().detectError(false, 'test')
 
     expect(wrapper).toHaveState({ errorsDetected: ['anotherError'] })
-  })
-  it('disables Button when no count is selected', () => {
-    const props = createTestProps({
-      drafts: [
-        {
-          draftId: 4,
-          familyData: {
-            familyMembersList: [
-              {
-                firstName: 'Juan',
-                lastName: 'Perez',
-                socioEconomicAnswers: [
-                  {
-                    key: 'educationPersonMostStudied',
-                    value: 'SCHOOL-COMPLETE'
-                  },
-                  { key: 'receiveStateIncome', value: 'NO' }
-                ]
-              }
-            ]
-          }
-        }
-      ]
-    })
-    wrapper = shallow(<FamilyMembersNames {...props} />)
-    wrapper.instance().errorsDetected = ['error']
-    wrapper.setState({ errorsDetected: ['error'] })
-    expect(
-      wrapper
-        .find(Button)
-        .last()
-        .props().disabled
-    ).toBe(true)
-  })
-  it('disables Button when no name is inputed', () => {
-    const props = createTestProps({
-      drafts: [
-        {
-          draftId: 4,
-          personal_survey_data: {
-            firstName: 'Jane'
-          },
-          familyData: {
-            countFamilyMembers: 2,
-            familyMembersList: [
-              {
-                firstName: 'Juan'
-              },
-              {
-                firstName: ''
-              }
-            ]
-          }
-        }
-      ]
-    })
-    wrapper = shallow(<FamilyMembersNames {...props} />)
-    wrapper.instance().errorsDetected = ['error']
-    wrapper.setState({ errorsDetected: ['error'] })
-    expect(
-      wrapper
-        .find(Button)
-        .last()
-        .props().disabled
-    ).toBe(true)
   })
 })
 

--- a/src/screens/lifemap/AddAchievement.js
+++ b/src/screens/lifemap/AddAchievement.js
@@ -51,13 +51,19 @@ export class AddAchievement extends Component {
     )[0]
 
   addAchievement = () => {
-    const { action, roadmap, indicator } = this.state
-    this.props.addSurveyPriorityAcheivementData({
-      id: this.props.navigation.getParam('draftId'),
-      category: 'achievements',
-      payload: { action, roadmap, indicator }
-    })
-    this.props.navigation.goBack()
+    if (this.errorsDetected.length) {
+      this.setState({
+        showErrors: true
+      })
+    } else {
+      const { action, roadmap, indicator } = this.state
+      this.props.addSurveyPriorityAcheivementData({
+        id: this.props.navigation.getParam('draftId'),
+        category: 'achievements',
+        payload: { action, roadmap, indicator }
+      })
+      this.props.navigation.goBack()
+    }
   }
 
   getAchievementValue = draft => {

--- a/src/screens/lifemap/AddAchievement.js
+++ b/src/screens/lifemap/AddAchievement.js
@@ -19,6 +19,7 @@ export class AddAchievement extends Component {
     action: '',
     roadmap: '',
     errorsDetected: [],
+    showErrors: false,
     indicator: this.props.navigation.getParam('indicator')
   }
 
@@ -69,6 +70,7 @@ export class AddAchievement extends Component {
 
   render() {
     const { t } = this.props
+    const { showErrors } = this.state
     const draft = this.getDraft()
     const achievement = this.getAchievementValue(draft)
 
@@ -104,6 +106,7 @@ export class AddAchievement extends Component {
           <TextInput
             field="action"
             required
+            showErrors={showErrors}
             detectError={this.detectError}
             onChangeText={text => this.setState({ action: text })}
             placeholder={
@@ -127,7 +130,6 @@ export class AddAchievement extends Component {
           <Button
             id="save"
             colored
-            disabled={!!this.errorsDetected.length}
             text={t('general.save')}
             handleClick={() => this.addAchievement()}
           />

--- a/src/screens/lifemap/FamilyMembersNames.js
+++ b/src/screens/lifemap/FamilyMembersNames.js
@@ -105,6 +105,10 @@ export class FamilyMembersNames extends Component {
       })
     }
 
+    this.setState({
+      showErrors: false
+    })
+
     this.props.addSurveyData(this.draftId, 'familyData', {
       [field]: text
     })

--- a/src/screens/lifemap/FamilyMembersNames.js
+++ b/src/screens/lifemap/FamilyMembersNames.js
@@ -22,7 +22,7 @@ export class FamilyMembersNames extends Component {
 
   errorsDetected = []
 
-  state = { errorsDetected: [] }
+  state = { errorsDetected: [], showErrors: false }
 
   componentDidMount() {
     this.props.addDraftProgress(this.draftId, {
@@ -56,15 +56,21 @@ export class FamilyMembersNames extends Component {
   }
 
   handleClick() {
-    this.getFieldValue('countFamilyMembers') > 1
-      ? this.props.navigation.navigate('FamilyMembersGender', {
-          draftId: this.draftId,
-          survey: this.survey
-        })
-      : this.props.navigation.navigate('Location', {
-          draftId: this.draftId,
-          survey: this.survey
-        })
+    if (this.errorsDetected.length) {
+      this.setState({
+        showErrors: true
+      })
+    } else {
+      this.getFieldValue('countFamilyMembers') > 1
+        ? this.props.navigation.navigate('FamilyMembersGender', {
+            draftId: this.draftId,
+            survey: this.survey
+          })
+        : this.props.navigation.navigate('Location', {
+            draftId: this.draftId,
+            survey: this.survey
+          })
+    }
   }
   getDraft = () =>
     this.props.drafts.filter(draft => draft.draftId === this.draftId)[0]
@@ -117,6 +123,7 @@ export class FamilyMembersNames extends Component {
 
   render() {
     const { t } = this.props
+    const { showErrors } = this.state
     const draft = this.getDraft()
 
     const familyMembersCount = draft.familyData.countFamilyMembers
@@ -140,6 +147,7 @@ export class FamilyMembersNames extends Component {
             field="countFamilyMembers"
             value={this.getFieldValue('countFamilyMembers') || ''}
             detectError={this.detectError}
+            showErrors={showErrors}
             options={Array(10)
               .fill()
               .map((item, index) => ({
@@ -158,6 +166,7 @@ export class FamilyMembersNames extends Component {
             required
             readonly
             detectError={this.detectError}
+            showErrors={showErrors}
           />
           {familyMembersCount.map((item, i) => (
             <TextInput
@@ -172,6 +181,7 @@ export class FamilyMembersNames extends Component {
               }
               required
               detectError={this.detectError}
+              showErrors={showErrors}
             />
           ))}
         </View>
@@ -180,7 +190,6 @@ export class FamilyMembersNames extends Component {
           <Button
             colored
             text={t('general.continue')}
-            disabled={!!this.errorsDetected.length}
             handleClick={() => this.handleClick(draft)}
           />
         </View>

--- a/src/screens/lifemap/FamilyParticipant.js
+++ b/src/screens/lifemap/FamilyParticipant.js
@@ -33,7 +33,7 @@ export class FamilyParticipant extends Component {
 
   errorsDetected = []
 
-  state = { errorsDetected: [] }
+  state = { errorsDetected: [], showErrors: false }
 
   detectError = (error, field) => {
     if (error && !this.errorsDetected.includes(field)) {
@@ -82,10 +82,16 @@ export class FamilyParticipant extends Component {
   }
 
   handleClick() {
-    this.props.navigation.navigate('FamilyMembersNames', {
-      draftId: this.draftId,
-      survey: this.survey
-    })
+    if (this.errorsDetected.length) {
+      this.setState({
+        showErrors: true
+      })
+    } else {
+      this.props.navigation.navigate('FamilyMembersNames', {
+        draftId: this.draftId,
+        survey: this.survey
+      })
+    }
   }
 
   getFieldValue = (draft, field) => {
@@ -115,6 +121,7 @@ export class FamilyParticipant extends Component {
 
   render() {
     const { t } = this.props
+    const { showErrors } = this.state
     const draft = this.props.drafts.filter(
       draft => draft.draftId === this.draftId
     )[0]
@@ -138,6 +145,7 @@ export class FamilyParticipant extends Component {
             value={this.getFieldValue(draft, 'firstName') || ''}
             required
             detectError={this.detectError}
+            showErrors={showErrors}
           />
           <TextInput
             field="lastName"
@@ -147,6 +155,7 @@ export class FamilyParticipant extends Component {
             value={this.getFieldValue(draft, 'lastName') || ''}
             required
             detectError={this.detectError}
+            showErrors={showErrors}
           />
           <Select
             id="gender"
@@ -157,6 +166,7 @@ export class FamilyParticipant extends Component {
             field="gender"
             value={this.getFieldValue(draft, 'gender') || ''}
             detectError={this.detectError}
+            showErrors={showErrors}
             options={this.gender}
           />
 
@@ -165,6 +175,7 @@ export class FamilyParticipant extends Component {
             label={t('views.family.dateOfBirth')}
             field="birthDate"
             detectError={this.detectError}
+            showErrors={showErrors}
             onValidDate={this.addSurveyData}
             value={this.getFieldValue(draft, 'birthDate')}
           />
@@ -177,6 +188,7 @@ export class FamilyParticipant extends Component {
             field="documentType"
             value={this.getFieldValue(draft, 'documentType') || ''}
             detectError={this.detectError}
+            showErrors={showErrors}
             options={this.documentType}
           />
           <TextInput
@@ -186,6 +198,7 @@ export class FamilyParticipant extends Component {
             value={this.getFieldValue(draft, 'documentNumber')}
             placeholder={t('views.family.documentNumber')}
             detectError={this.detectError}
+            showErrors={showErrors}
           />
           <Select
             required
@@ -197,6 +210,7 @@ export class FamilyParticipant extends Component {
             field="birthCountry"
             value={this.getFieldValue(draft, 'birthCountry') || ''}
             detectError={this.detectError}
+            showErrors={showErrors}
           />
           <TextInput
             onChangeText={this.addSurveyData}
@@ -205,6 +219,7 @@ export class FamilyParticipant extends Component {
             placeholder={t('views.family.email')}
             validation="email"
             detectError={this.detectError}
+            showErrors={showErrors}
           />
           <TextInput
             onChangeText={this.addSurveyData}
@@ -213,11 +228,11 @@ export class FamilyParticipant extends Component {
             placeholder={t('views.family.phone')}
             validation="phoneNumber"
             detectError={this.detectError}
+            showErrors={showErrors}
           />
         </View>
         <View style={{ height: 50, marginTop: 50 }}>
           <Button
-            disabled={!!this.errorsDetected.length}
             colored
             text={t('general.continue')}
             handleClick={() => this.handleClick()}

--- a/src/screens/lifemap/Location.js
+++ b/src/screens/lifemap/Location.js
@@ -26,6 +26,7 @@ import center from '../../../assets/images/centerMap.png'
 
 export class Location extends Component {
   state = {
+    showErrors: false,
     latitude: null,
     longitude: null,
     latitudeDelta: 0.005,
@@ -227,13 +228,19 @@ export class Location extends Component {
   }
 
   handleClick = () => {
-    this.addSurveyData(this.state.accuracy, 'accuracy')
-    this.addSurveyData(this.state.latitude, 'latitude')
-    this.addSurveyData(this.state.longitude, 'longitude')
-    this.props.navigation.replace('SocioEconomicQuestion', {
-      draftId: this.draftId,
-      survey: this.survey
-    })
+    if (this.errorsDetected.length) {
+      this.setState({
+        showErrors: true
+      })
+    } else {
+      this.addSurveyData(this.state.accuracy, 'accuracy')
+      this.addSurveyData(this.state.latitude, 'latitude')
+      this.addSurveyData(this.state.longitude, 'longitude')
+      this.props.navigation.replace('SocioEconomicQuestion', {
+        draftId: this.draftId,
+        survey: this.survey
+      })
+    }
   }
   render() {
     const { t } = this.props
@@ -247,7 +254,8 @@ export class Location extends Component {
       searchAddress,
       centeringMap,
       isOnline,
-      showMap
+      showMap,
+      showErrors
     } = this.state
 
     const draft = this.getDraft()
@@ -364,6 +372,7 @@ export class Location extends Component {
             <Select
               id="countrySelect"
               required
+              showErrors={showErrors}
               onChange={this.addSurveyData}
               label={t('views.family.country')}
               countrySelect
@@ -396,7 +405,6 @@ export class Location extends Component {
         <View style={{ marginTop: 15 }}>
           <Button
             id="continue"
-            disabled={!!this.errorsDetected.length}
             colored
             text={t('general.continue')}
             handleClick={this.handleClick}

--- a/src/screens/lifemap/SocioEconomicQuestion.js
+++ b/src/screens/lifemap/SocioEconomicQuestion.js
@@ -183,7 +183,6 @@ export class SocioEconomicQuestion extends Component {
     })
   }
   submitForm = () => {
-    console.log(this.errorsDetected.length)
     if (this.errorsDetected.length) {
       this.setState({
         showErrors: true

--- a/src/screens/lifemap/SocioEconomicQuestion.js
+++ b/src/screens/lifemap/SocioEconomicQuestion.js
@@ -23,7 +23,7 @@ export class SocioEconomicQuestion extends Component {
 
   errorsDetected = []
 
-  state = { errorsDetected: [] }
+  state = { errorsDetected: [], showErrors: false }
   draftId = this.props.navigation.getParam('draftId')
   survey = this.props.navigation.getParam('survey')
 
@@ -182,8 +182,34 @@ export class SocioEconomicQuestion extends Component {
       errorsDetected: this.errorsDetected
     })
   }
+  submitForm = () => {
+    console.log(this.errorsDetected.length)
+    if (this.errorsDetected.length) {
+      this.setState({
+        showErrors: true
+      })
+    } else {
+      const socioEconomics = this.props.navigation.getParam('socioEconomics')
+
+      socioEconomics.currentScreen === socioEconomics.totalScreens
+        ? this.props.navigation.navigate('BeginLifemap', {
+            draftId: this.draftId,
+            survey: this.survey
+          })
+        : this.props.navigation.push('SocioEconomicQuestion', {
+            draftId: this.draftId,
+            survey: this.survey,
+            socioEconomics: {
+              currentScreen: socioEconomics.currentScreen + 1,
+              questionsPerScreen: socioEconomics.questionsPerScreen,
+              totalScreens: socioEconomics.totalScreens
+            }
+          })
+    }
+  }
   render() {
     const { t } = this.props
+    const { showErrors } = this.state
     const draft = this.props.drafts.find(
       draft => draft.draftId === this.draftId
     )
@@ -213,6 +239,7 @@ export class SocioEconomicQuestion extends Component {
                   required={question.required}
                   onChange={this.addSurveyData}
                   placeholder={question.questionText}
+                  showErrors={showErrors}
                   label={question.questionText}
                   field={question.codeName}
                   value={this.getFieldValue(draft, question.codeName) || ''}
@@ -226,6 +253,7 @@ export class SocioEconomicQuestion extends Component {
                   required={question.required}
                   onChangeText={this.addSurveyData}
                   placeholder={question.questionText}
+                  showErrors={showErrors}
                   field={question.codeName}
                   value={this.getFieldValue(draft, question.codeName) || ''}
                   detectError={this.detectError}
@@ -239,6 +267,7 @@ export class SocioEconomicQuestion extends Component {
                   required={question.required}
                   onChangeText={this.addSurveyData}
                   placeholder={question.questionText}
+                  showErrors={showErrors}
                   field={question.codeName}
                   value={this.getFieldValue(draft, question.codeName) || ''}
                   detectError={this.detectError}
@@ -264,6 +293,7 @@ export class SocioEconomicQuestion extends Component {
                           this.addSurveyFamilyMemberData(text, field, i)
                         }
                         placeholder={question.questionText}
+                        showErrors={showErrors}
                         label={question.questionText}
                         field={question.codeName}
                         value={
@@ -285,6 +315,7 @@ export class SocioEconomicQuestion extends Component {
                           this.addSurveyFamilyMemberData(text, field, i)
                         }
                         placeholder={question.questionText}
+                        showErrors={showErrors}
                         field={question.codeName}
                         value={
                           this.getFamilyMemberFieldValue(
@@ -309,25 +340,9 @@ export class SocioEconomicQuestion extends Component {
         <View style={{ marginTop: 15, height: 50 }}>
           <Button
             id="continue"
-            disabled={!!this.errorsDetected.length}
             colored
             text={t('general.continue')}
-            handleClick={() =>
-              socioEconomics.currentScreen === socioEconomics.totalScreens
-                ? this.props.navigation.navigate('BeginLifemap', {
-                    draftId: this.draftId,
-                    survey: this.survey
-                  })
-                : this.props.navigation.push('SocioEconomicQuestion', {
-                    draftId: this.draftId,
-                    survey: this.survey,
-                    socioEconomics: {
-                      currentScreen: socioEconomics.currentScreen + 1,
-                      questionsPerScreen: socioEconomics.questionsPerScreen,
-                      totalScreens: socioEconomics.totalScreens
-                    }
-                  })
-            }
+            handleClick={this.submitForm}
           />
         </View>
       </ScrollView>


### PR DESCRIPTION
The change is described in #232, but in a nutshell when we have a form, the continue button is no longer disabled. Instead if you click on it any errors that are present in the form would show. The current validation on the fly (when you blur from a field) is unchanged. We should still show messages while editing.

**To Test**
You don't need to delete any data. You can also use an existing draft and just go back screens and remove required data. Go through the following pages:

- Primary participant
- Family member names
- Family location
- Socio economic questions (do 2 different surveys to be sure)
- Adding a priority
- Adding an achievement

And check the following:

- The continue/save button is not disabled at any time
- Clicking on it while there are empty required fields shows errors on those fields
- Fixing errors and clicking the button moves to the correct page
- Moving back within the survey works as expected
- Adding an achievement or priority doesn't add extra data to the draft

The Family gender and birthdays screens don't have required fields and will always allow you to continue.
