### PR TITLE
Show families sync on loading screen without blocking app

### DIFF
--- a/src/components/NavWrapper.js
+++ b/src/components/NavWrapper.js
@@ -1,9 +1,8 @@
 import React, { Component } from 'react'
-import { View, StyleSheet, StatusBar } from 'react-native'
+import { View, StyleSheet, StatusBar, Dimensions } from 'react-native'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { setSyncedState, setDimensions } from '../redux/actions'
-import { Dimensions } from 'react-native'
 import { LoginStack, AppStack, LoadingStack } from './navigation'
 import colors from '../theme.json'
 
@@ -41,7 +40,8 @@ const styles = StyleSheet.create({
 NavWrapper.propTypes = {
   user: PropTypes.object.isRequired,
   sync: PropTypes.object.isRequired,
-  setSyncedState: PropTypes.func.isRequired
+  setSyncedState: PropTypes.func.isRequired,
+  setDimensions: PropTypes.func.isRequired
 }
 
 const mapStateToProps = ({ user, sync, dimensions }) => ({

--- a/src/screens/Loading.js
+++ b/src/screens/Loading.js
@@ -29,8 +29,8 @@ export class Loading extends Component {
     this.setState({
       loadingData: true
     })
-    this.props.loadSurveys(url[this.props.env], this.props.user.token)
     this.props.loadFamilies(url[this.props.env], this.props.user.token)
+    this.props.loadSurveys(url[this.props.env], this.props.user.token)
   }
   checkHydration = () => {
     if (getHydrationState() === false) {
@@ -77,7 +77,7 @@ export class Loading extends Component {
   }
 
   render() {
-    const { sync, surveys } = this.props
+    const { sync, surveys, families } = this.props
 
     return (
       <View style={[globalStyles.container, styles.view]}>
@@ -90,14 +90,12 @@ export class Loading extends Component {
           />
 
           <Text style={globalStyles.h3}>Yes!</Text>
-          <Text style={globalStyles.subline}>
-            We will be ready soon.
-            {/* {this.props.time === 'ok'
-              ? 'We will be ready soon.'
-            : 'This might take a while...'} */}
-          </Text>
+          <Text style={globalStyles.subline}>We will be ready soon.</Text>
           {this.state.loadingData ? (
             <View style={styles.sync}>
+              <Text>
+                Syncing families: {families.length} / {families.length}
+              </Text>
               <Text>
                 Syncing surveys: {surveys.length} / {surveys.length}
               </Text>
@@ -123,6 +121,7 @@ Loading.propTypes = {
   user: PropTypes.object.isRequired,
   sync: PropTypes.object.isRequired,
   surveys: PropTypes.array.isRequired,
+  families: PropTypes.array.isRequired,
   offline: PropTypes.object
 }
 
@@ -149,12 +148,13 @@ const styles = StyleSheet.create({
   }
 })
 
-const mapStateToProps = ({ sync, surveys, env, user, offline }) => ({
+const mapStateToProps = ({ sync, surveys, env, user, offline, families }) => ({
   sync,
   surveys,
   env,
   user,
-  offline
+  offline,
+  families
 })
 
 const mapDispatchToProps = {


### PR DESCRIPTION
We now sync the families as well as surveys and images. We should reflect that in the loading screen.

**To Test**
1. Log out from the app.
2. After that... guess what. Log in :) No matter the user.
3. The loading screen should show surveys and images, but now also families. It might take some time for the 0/0 to become something else. At this stage I have no idea how to load surveys or families 1 by 1, so I show the total when they get fetched.
4. Once all is synced we are shown the Dashboard.
5. Logout again and test that you can log in the app even if the families don't fetch. You can simulate this either, by commenting out [this line](https://github.com/FundacionParaguaya/MentorApp/blob/sync-families/src/screens/Loading.js#L32), or going [here](https://github.com/FundacionParaguaya/MentorApp/blob/sync-families/src/redux/actions.js#L87) and doing something weird to the API call, like changing the url or the header in some way that would result in a bad call.
6. What should happen is families will stay 0/0, but the other data will sync.
