### PR TITLE
Auto select country

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -158,7 +158,7 @@ class Select extends Component {
               <View style={styles.dropdown}>
                 {countrySelect ? (
                   <ScrollView>
-                    {countries.map((item, i) => (
+                    {countries.map(item => (
                       <TouchableOpacity
                         key={item.code}
                         onPress={() => this.validateInput(item.code)}

--- a/src/screens/__tests__/FamilyParticipant.test.js
+++ b/src/screens/__tests__/FamilyParticipant.test.js
@@ -155,6 +155,10 @@ describe('Family Participant View', () => {
       expect(wrapper.find(Button)).toHaveLength(1)
     })
 
+    it('country select has preselected default country', () => {
+      expect(wrapper.find('#country')).toHaveProp({ value: 'BG' })
+    })
+
     it('sets proper TextInput value from draft', () => {
       const props = createTestProps({
         navigation: {

--- a/src/screens/__tests__/Location.test.js
+++ b/src/screens/__tests__/Location.test.js
@@ -300,4 +300,8 @@ describe('Render optimization', () => {
     wrapper = shallow(<Location {...props} />)
     expect(wrapper.instance().props.drafts[2]).toBeFalsy()
   })
+
+  it('country select has preselected default country', () => {
+    expect(wrapper.find('#countrySelect')).toHaveProp({ value: 'BG' })
+  })
 })

--- a/src/screens/lifemap/FamilyParticipant.js
+++ b/src/screens/lifemap/FamilyParticipant.js
@@ -208,7 +208,10 @@ export class FamilyParticipant extends Component {
             country={this.survey.surveyConfig.surveyLocation.country}
             placeholder={t('views.family.selectACountry')}
             field="birthCountry"
-            value={this.getFieldValue(draft, 'birthCountry') || ''}
+            value={
+              this.getFieldValue(draft, 'birthCountry') ||
+              this.survey.surveyConfig.surveyLocation.country
+            }
             detectError={this.detectError}
             showErrors={showErrors}
           />

--- a/src/screens/lifemap/FamilyParticipant.js
+++ b/src/screens/lifemap/FamilyParticipant.js
@@ -201,6 +201,7 @@ export class FamilyParticipant extends Component {
             showErrors={showErrors}
           />
           <Select
+            id="country"
             required
             onChange={this.addSurveyData}
             label={t('views.family.countryOfBirth')}

--- a/src/screens/lifemap/Location.js
+++ b/src/screens/lifemap/Location.js
@@ -389,7 +389,10 @@ export class Location extends Component {
               countrySelect
               placeholder={t('views.family.selectACountry')}
               field="country"
-              value={this.getFieldValue(draft, 'country') || ''}
+              value={
+                this.getFieldValue(draft, 'country') ||
+                this.survey.surveyConfig.surveyLocation.country
+              }
               detectError={this.detectError}
               country={this.survey.surveyConfig.surveyLocation.country}
             />


### PR DESCRIPTION
If a survey has a default country, auto select that country in the country select dropdown on primary participan and family location screens.

**To Test**
1. Start a brand new life map with any survey.
2. Open primary participant.
3. Check if the given survey's country is autoselected.
4. Move on to family location and check step 3 again.
5. Repeat steps 1 - 4 with a different country.
