### PR TITLE
Fixed footer in lifemap process

### DIFF
--- a/src/components/StickyFooter.js
+++ b/src/components/StickyFooter.js
@@ -1,0 +1,39 @@
+import React, { Component } from 'react'
+import { View, ScrollView, StyleSheet } from 'react-native'
+import Button from './Button'
+import PropTypes from 'prop-types'
+import globalStyles from '../globalStyles'
+
+export default class StickyFooter extends Component {
+  render() {
+    return (
+      <View style={[globalStyles.background, styles.contentContainer]}>
+        <ScrollView>{this.props.children}</ScrollView>
+        <View style={{ height: 50 }}>
+          <Button
+            id="continue"
+            colored
+            text={this.props.continueLabel}
+            handleClick={this.props.handleClick}
+          />
+        </View>
+      </View>
+    )
+  }
+}
+
+StickyFooter.propTypes = {
+  children: PropTypes.array.isRequired,
+  handleClick: PropTypes.func,
+  continueLabel: PropTypes.string
+}
+
+const styles = StyleSheet.create({
+  contentContainer: {
+    paddingTop: 20,
+    flex: 1,
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'stretch'
+  }
+})

--- a/src/components/__tests__/StickyFooter.test.js
+++ b/src/components/__tests__/StickyFooter.test.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { ScrollView } from 'react-native'
+import Button from '../Button'
+import StickyFooter from '../StickyFooter'
+
+const createTestProps = props => ({
+  children: [],
+  handleClick: jest.fn(),
+  continueLabel: 'Continue',
+  ...props
+})
+
+describe('Sticky Footer', () => {
+  let wrapper
+  let props
+  beforeEach(() => {
+    props = createTestProps()
+    wrapper = shallow(<StickyFooter {...props} />)
+  })
+  it('renders the page content in a ScrollView', () => {
+    expect(wrapper.find(ScrollView)).toHaveLength(1)
+  })
+  it('renders the continue/save button with the proper label', () => {
+    expect(wrapper.find(Button)).toHaveLength(1)
+    expect(wrapper.find(Button)).toHaveProp({ text: 'Continue' })
+  })
+  it('pressing continue/save fires the handleClick function', () => {
+    wrapper
+      .find(Button)
+      .props()
+      .handleClick()
+    expect(props.handleClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/screens/Dashboard.js
+++ b/src/screens/Dashboard.js
@@ -38,7 +38,6 @@ export class Dashboard extends Component {
     this.clearTimers()
   }
   navigateToDraft = draft => {
-    console.log(draft)
     if (
       draft.progress.screen !== 'Question' &&
       draft.progress.screen !== 'Skipped' &&

--- a/src/screens/__tests__/AddAchievement.test.js
+++ b/src/screens/__tests__/AddAchievement.test.js
@@ -4,6 +4,7 @@ import { Text } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import { AddAchievement } from '../lifemap/AddAchievement'
 import TextInput from '../../components/TextInput'
+import StickyFooter from '../../components/StickyFooter'
 
 const createTestProps = props => ({
   t: value => value,
@@ -31,6 +32,11 @@ describe('AddAchievement View', () => {
     wrapper = shallow(<AddAchievement {...props} />)
   })
   describe('rendering', () => {
+    it('renders the continue button with proper label', () => {
+      expect(wrapper.find(StickyFooter)).toHaveProp({
+        continueLabel: 'general.save'
+      })
+    })
     it('renders Icon', () => {
       expect(wrapper.find(Icon)).toHaveLength(1)
     })
@@ -101,5 +107,16 @@ describe('Render optimization', () => {
     })
     wrapper = shallow(<AddAchievement {...props} />)
     expect(wrapper.instance().props.drafts[1]).toBeFalsy()
+  })
+
+  it('saves the achievement', () => {
+    wrapper
+      .find(StickyFooter)
+      .props()
+      .handleClick()
+
+    expect(
+      wrapper.instance().props.addSurveyPriorityAcheivementData
+    ).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/screens/__tests__/AddAchievement.test.js
+++ b/src/screens/__tests__/AddAchievement.test.js
@@ -1,12 +1,9 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { ScrollView, Text } from 'react-native'
-
+import { Text } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
-
 import { AddAchievement } from '../lifemap/AddAchievement'
 import TextInput from '../../components/TextInput'
-import Button from '../../components/Button'
 
 const createTestProps = props => ({
   t: value => value,
@@ -34,17 +31,11 @@ describe('AddAchievement View', () => {
     wrapper = shallow(<AddAchievement {...props} />)
   })
   describe('rendering', () => {
-    it('renders ScrollView', () => {
-      expect(wrapper.find(ScrollView)).toHaveLength(1)
-    })
     it('renders Icon', () => {
       expect(wrapper.find(Icon)).toHaveLength(1)
     })
     it('renders Text', () => {
       expect(wrapper.find(Text)).toHaveLength(2)
-    })
-    it('renders Button', () => {
-      expect(wrapper.find(Button)).toHaveLength(1)
     })
   })
 
@@ -75,17 +66,6 @@ describe('AddAchievement View', () => {
         .props()
         .onChangeText('Some roadmap')
       expect(wrapper.instance().state.roadmap).toEqual('Some roadmap')
-    })
-
-    it('saves the achievement', () => {
-      wrapper
-        .find(Button)
-        .props()
-        .handleClick()
-
-      expect(
-        wrapper.instance().props.addSurveyPriorityAcheivementData
-      ).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/screens/__tests__/AddPriority.test.js
+++ b/src/screens/__tests__/AddPriority.test.js
@@ -1,12 +1,11 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { ScrollView, Text } from 'react-native'
+import { Text } from 'react-native'
 
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
 import { AddPriority } from '../lifemap/AddPriority'
 import TextInput from '../../components/TextInput'
-import Button from '../../components/Button'
 import Counter from '../../components/Counter'
 
 const createTestProps = props => ({
@@ -35,9 +34,6 @@ describe('AddPriority View', () => {
     wrapper = shallow(<AddPriority {...props} />)
   })
   describe('rendering', () => {
-    it('renders ScrollView', () => {
-      expect(wrapper.find(ScrollView)).toHaveLength(1)
-    })
     it('renders Icon', () => {
       expect(wrapper.find(Icon)).toHaveLength(1)
     })
@@ -46,9 +42,6 @@ describe('AddPriority View', () => {
     })
     it('renders Counter', () => {
       expect(wrapper.find(Counter)).toHaveLength(1)
-    })
-    it('renders Button', () => {
-      expect(wrapper.find(Button)).toHaveLength(1)
     })
   })
 
@@ -99,28 +92,6 @@ describe('AddPriority View', () => {
         .props()
         .onChangeText('Some action')
       expect(wrapper.instance().state.action).toEqual('Some action')
-    })
-    it('doesn\'t save the priority if no months entered', () => {
-      wrapper
-        .find(Button)
-        .props()
-        .handleClick()
-
-      expect(
-        wrapper.instance().props.addSurveyPriorityAcheivementData
-      ).toHaveBeenCalledTimes(0)
-    })
-    it('saves the priority if valid', () => {
-      wrapper.instance().setState({ estimatedDate: 2 })
-
-      wrapper
-        .find(Button)
-        .props()
-        .handleClick()
-
-      expect(
-        wrapper.instance().props.addSurveyPriorityAcheivementData
-      ).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/screens/__tests__/AddPriority.test.js
+++ b/src/screens/__tests__/AddPriority.test.js
@@ -1,9 +1,8 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { Text } from 'react-native'
-
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
-
+import StickyFooter from '../../components/StickyFooter'
 import { AddPriority } from '../lifemap/AddPriority'
 import TextInput from '../../components/TextInput'
 import Counter from '../../components/Counter'
@@ -34,6 +33,11 @@ describe('AddPriority View', () => {
     wrapper = shallow(<AddPriority {...props} />)
   })
   describe('rendering', () => {
+    it('renders the continue button with proper label', () => {
+      expect(wrapper.find(StickyFooter)).toHaveProp({
+        continueLabel: 'general.save'
+      })
+    })
     it('renders Icon', () => {
       expect(wrapper.find(Icon)).toHaveLength(1)
     })
@@ -46,6 +50,28 @@ describe('AddPriority View', () => {
   })
 
   describe('functionality', () => {
+    it('doesn\'t save the priority if no months entered', () => {
+      wrapper
+        .find(StickyFooter)
+        .props()
+        .handleClick()
+
+      expect(
+        wrapper.instance().props.addSurveyPriorityAcheivementData
+      ).toHaveBeenCalledTimes(0)
+    })
+    it('saves the priority if valid', () => {
+      wrapper.instance().setState({ estimatedDate: 2 })
+
+      wrapper
+        .find(StickyFooter)
+        .props()
+        .handleClick()
+
+      expect(
+        wrapper.instance().props.addSurveyPriorityAcheivementData
+      ).toHaveBeenCalledTimes(1)
+    })
     it('has correct initial state', () => {
       expect(wrapper.instance().state).toEqual({
         action: '',

--- a/src/screens/__tests__/FamilyMembersBirthdates.test.js
+++ b/src/screens/__tests__/FamilyMembersBirthdates.test.js
@@ -1,9 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { ScrollView, Text } from 'react-native'
+import { Text } from 'react-native'
 import { FamilyMembersBirthdates } from '../lifemap/FamilyMembersBirthdates'
-
-import Button from '../../components/Button'
 import DateInputComponent from '../../components/DateInput'
 
 const createTestProps = props => ({
@@ -48,31 +46,11 @@ describe('FamilyMembersBirthDates View', () => {
     wrapper = shallow(<FamilyMembersBirthdates {...props} />)
   })
   describe('rendering', () => {
-    it('renders ScrollView', () => {
-      expect(wrapper.find(ScrollView)).toHaveLength(1)
-    })
-
-    it('renders Button', () => {
-      expect(wrapper.find(Button)).toHaveLength(1)
-    })
     it('renders DateInput', () => {
       expect(wrapper.find(DateInputComponent)).toHaveLength(1)
     })
     it('renders Text', () => {
       expect(wrapper.find(Text)).toHaveLength(1)
-    })
-  })
-
-  describe('functionality', () => {
-    it('calls navigate function when button is pressed', () => {
-      wrapper
-        .find(Button)
-        .props()
-        .handleClick()
-
-      expect(
-        wrapper.instance().props.navigation.navigate
-      ).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -91,25 +69,6 @@ describe('FamilyMembersBirthDates View', () => {
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
-  it('enables Button by default', () => {
-    expect(
-      wrapper
-        .find(Button)
-        .last()
-        .props().disabled
-    ).toBe(false)
-  })
-  it('disables Button when an error occurs', () => {
-    wrapper.instance().errorsDetected = ['error']
-    wrapper.setState({ errorsDetected: ['error'] })
-
-    expect(
-      wrapper
-        .find(Button)
-        .last()
-        .props().disabled
-    ).toBe(true)
-  })
   it('calls setParam on mount', () => {
     expect(wrapper.instance().props.navigation.setParams).toHaveBeenCalledTimes(
       1

--- a/src/screens/__tests__/FamilyMembersBirthdates.test.js
+++ b/src/screens/__tests__/FamilyMembersBirthdates.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme'
 import { Text } from 'react-native'
 import { FamilyMembersBirthdates } from '../lifemap/FamilyMembersBirthdates'
 import DateInputComponent from '../../components/DateInput'
+import StickyFooter from '../../components/StickyFooter'
 
 const createTestProps = props => ({
   t: value => value,
@@ -46,6 +47,11 @@ describe('FamilyMembersBirthDates View', () => {
     wrapper = shallow(<FamilyMembersBirthdates {...props} />)
   })
   describe('rendering', () => {
+    it('renders the continue button with proper label', () => {
+      expect(wrapper.find(StickyFooter)).toHaveProp({
+        continueLabel: 'general.continue'
+      })
+    })
     it('renders DateInput', () => {
       expect(wrapper.find(DateInputComponent)).toHaveLength(1)
     })
@@ -116,5 +122,16 @@ describe('Render optimization', () => {
 
     wrapper = shallow(<FamilyMembersBirthdates {...props} />)
     expect(wrapper.instance().props.drafts[1]).toBeFalsy()
+  })
+
+  it('calls navigate function when button is pressed', () => {
+    wrapper
+      .find(StickyFooter)
+      .props()
+      .handleClick()
+
+    expect(wrapper.instance().props.navigation.navigate).toHaveBeenCalledTimes(
+      1
+    )
   })
 })

--- a/src/screens/__tests__/FamilyMembersGender.test.js
+++ b/src/screens/__tests__/FamilyMembersGender.test.js
@@ -1,9 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { ScrollView, Text } from 'react-native'
+import { Text } from 'react-native'
 import { FamilyMembersGender } from '../lifemap/FamilyMembersGender'
-
-import Button from '../../components/Button'
 import Select from '../../components/Select'
 
 const createTestProps = props => ({
@@ -68,13 +66,6 @@ describe('FamilyMembersGender View', () => {
     wrapper = shallow(<FamilyMembersGender {...props} />)
   })
   describe('rendering', () => {
-    it('renders ScrollView', () => {
-      expect(wrapper.find(ScrollView)).toHaveLength(1)
-    })
-
-    it('renders Button', () => {
-      expect(wrapper.find(Button)).toHaveLength(1)
-    })
     it('renders Select', () => {
       expect(wrapper.find(Select)).toHaveLength(1)
     })
@@ -84,97 +75,67 @@ describe('FamilyMembersGender View', () => {
   })
 
   describe('functionality', () => {
-    it('calls navigate function when button is pressed', () => {
-      wrapper
-        .find(Button)
-        .props()
-        .handleClick()
+    it('gives Select the proper value', () => {
+      expect(wrapper.find(Select).props().value).toBe('F')
+    })
 
+    it('calls addFamilyMemberGender on change', () => {
+      const spy = jest.spyOn(wrapper.instance(), 'addFamilyMemberGender')
+
+      wrapper
+        .find(Select)
+        .last()
+        .props()
+        .onChange()
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls setParam on mount', () => {
       expect(
-        wrapper.instance().props.navigation.navigate
+        wrapper.instance().props.navigation.setParams
       ).toHaveBeenCalledTimes(1)
     })
-  })
-  it('gives Select the proper value', () => {
-    expect(wrapper.find(Select).props().value).toBe('F')
-  })
-
-  it('calls addFamilyMemberGender on change', () => {
-    const spy = jest.spyOn(wrapper.instance(), 'addFamilyMemberGender')
-
-    wrapper
-      .find(Select)
-      .last()
-      .props()
-      .onChange()
-    expect(spy).toHaveBeenCalledTimes(1)
-  })
-
-  it('enables Button by default', () => {
-    expect(
-      wrapper
-        .find(Button)
-        .last()
-        .props().disabled
-    ).toBe(false)
-  })
-
-  it('disables Button when an error occurs', () => {
-    wrapper.instance().errorsDetected = ['error']
-    wrapper.setState({ errorsDetected: ['error'] })
-
-    expect(
-      wrapper
-        .find(Button)
-        .last()
-        .props().disabled
-    ).toBe(true)
-  })
-  it('calls setParam on mount', () => {
-    expect(wrapper.instance().props.navigation.setParams).toHaveBeenCalledTimes(
-      1
-    )
-  })
-  it('calls addDraftProgress on mount', () => {
-    expect(wrapper.instance().props.addDraftProgress).toHaveBeenCalledTimes(1)
-  })
-  it('calls onPressBack', () => {
-    const spy = jest.spyOn(wrapper.instance(), 'onPressBack')
-
-    wrapper.instance().onPressBack()
-    expect(spy).toHaveBeenCalledTimes(1)
-  })
-})
-
-describe('Render optimization', () => {
-  let wrapper
-  let props
-  beforeEach(() => {
-    props = createTestProps()
-    wrapper = shallow(<FamilyMembersGender {...props} />)
-  })
-  it('checks if screen is focused before updating', () => {
-    wrapper.setProps({
-      drafts: [...wrapper.instance().props.drafts, { draftId: 5 }]
+    it('calls addDraftProgress on mount', () => {
+      expect(wrapper.instance().props.addDraftProgress).toHaveBeenCalledTimes(1)
     })
-    expect(wrapper.instance().props.navigation.isFocused).toHaveBeenCalledTimes(
-      1
-    )
+    it('calls onPressBack', () => {
+      const spy = jest.spyOn(wrapper.instance(), 'onPressBack')
+
+      wrapper.instance().onPressBack()
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
   })
-  it('updates screen if focused', () => {
-    wrapper.setProps({
-      drafts: [...wrapper.instance().props.drafts, { draftId: 5 }]
+
+  describe('Render optimization', () => {
+    let wrapper
+    let props
+    beforeEach(() => {
+      props = createTestProps()
+      wrapper = shallow(<FamilyMembersGender {...props} />)
     })
-    expect(wrapper.instance().props.drafts[1]).toEqual({ draftId: 5 })
-  })
-  it('does not update screen if not focused', () => {
-    wrapper.setProps({
-      drafts: [...wrapper.instance().props.drafts, { draftId: 5 }]
+    it('checks if screen is focused before updating', () => {
+      wrapper.setProps({
+        drafts: [...wrapper.instance().props.drafts, { draftId: 5 }]
+      })
+      expect(
+        wrapper.instance().props.navigation.isFocused
+      ).toHaveBeenCalledTimes(1)
     })
-    props = createTestProps({
-      navigation: { ...props.navigation, isFocused: jest.fn(() => false) }
+    it('updates screen if focused', () => {
+      wrapper.setProps({
+        drafts: [...wrapper.instance().props.drafts, { draftId: 5 }]
+      })
+      expect(wrapper.instance().props.drafts[1]).toEqual({ draftId: 5 })
     })
-    wrapper = shallow(<FamilyMembersGender {...props} />)
-    expect(wrapper.instance().props.drafts[1]).toBeFalsy()
+    it('does not update screen if not focused', () => {
+      wrapper.setProps({
+        drafts: [...wrapper.instance().props.drafts, { draftId: 5 }]
+      })
+      props = createTestProps({
+        navigation: { ...props.navigation, isFocused: jest.fn(() => false) }
+      })
+      wrapper = shallow(<FamilyMembersGender {...props} />)
+      expect(wrapper.instance().props.drafts[1]).toBeFalsy()
+    })
   })
 })

--- a/src/screens/__tests__/FamilyMembersGender.test.js
+++ b/src/screens/__tests__/FamilyMembersGender.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme'
 import { Text } from 'react-native'
 import { FamilyMembersGender } from '../lifemap/FamilyMembersGender'
 import Select from '../../components/Select'
+import StickyFooter from '../../components/StickyFooter'
 
 const createTestProps = props => ({
   t: value => value,
@@ -66,6 +67,11 @@ describe('FamilyMembersGender View', () => {
     wrapper = shallow(<FamilyMembersGender {...props} />)
   })
   describe('rendering', () => {
+    it('renders the continue button with proper label', () => {
+      expect(wrapper.find(StickyFooter)).toHaveProp({
+        continueLabel: 'general.continue'
+      })
+    })
     it('renders Select', () => {
       expect(wrapper.find(Select)).toHaveLength(1)
     })
@@ -75,6 +81,16 @@ describe('FamilyMembersGender View', () => {
   })
 
   describe('functionality', () => {
+    it('calls navigate function when button is pressed', () => {
+      wrapper
+        .find(StickyFooter)
+        .props()
+        .handleClick()
+
+      expect(
+        wrapper.instance().props.navigation.navigate
+      ).toHaveBeenCalledTimes(1)
+    })
     it('gives Select the proper value', () => {
       expect(wrapper.find(Select).props().value).toBe('F')
     })

--- a/src/screens/__tests__/FamilyMembersNames.test.js
+++ b/src/screens/__tests__/FamilyMembersNames.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme'
 import { FamilyMembersNames } from '../lifemap/FamilyMembersNames'
 import TextInput from '../../components/TextInput'
 import Select from '../../components/Select'
+import StickyFooter from '../../components/StickyFooter'
 
 const createTestProps = props => ({
   t: value => value,
@@ -56,6 +57,11 @@ describe('FamilyMembersNames View', () => {
     wrapper = shallow(<FamilyMembersNames {...props} />)
   })
   describe('rendering', () => {
+    it('renders the continue button with proper label', () => {
+      expect(wrapper.find(StickyFooter)).toHaveProp({
+        continueLabel: 'general.continue'
+      })
+    })
     it('renders Select', () => {
       expect(wrapper.find(Select)).toHaveLength(1)
     })
@@ -65,6 +71,16 @@ describe('FamilyMembersNames View', () => {
   })
 
   describe('functionality', () => {
+    it('calls navigate function when button is pressed', () => {
+      wrapper
+        .find(StickyFooter)
+        .props()
+        .handleClick()
+
+      expect(
+        wrapper.instance().props.navigation.navigate
+      ).toHaveBeenCalledTimes(1)
+    })
     it('calls setParam on mount', () => {
       expect(
         wrapper.instance().props.navigation.setParams

--- a/src/screens/__tests__/FamilyMembersNames.test.js
+++ b/src/screens/__tests__/FamilyMembersNames.test.js
@@ -1,9 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { ScrollView } from 'react-native'
 import { FamilyMembersNames } from '../lifemap/FamilyMembersNames'
-
-import Button from '../../components/Button'
 import TextInput from '../../components/TextInput'
 import Select from '../../components/Select'
 
@@ -59,13 +56,6 @@ describe('FamilyMembersNames View', () => {
     wrapper = shallow(<FamilyMembersNames {...props} />)
   })
   describe('rendering', () => {
-    it('renders ScrollView', () => {
-      expect(wrapper.find(ScrollView)).toHaveLength(1)
-    })
-
-    it('renders Button', () => {
-      expect(wrapper.find(Button)).toHaveLength(1)
-    })
     it('renders Select', () => {
       expect(wrapper.find(Select)).toHaveLength(1)
     })
@@ -88,16 +78,6 @@ describe('FamilyMembersNames View', () => {
 
       wrapper.instance().onPressBack()
       expect(spy).toHaveBeenCalledTimes(1)
-    })
-    it('calls navigate function when button is pressed', () => {
-      wrapper
-        .find(Button)
-        .props()
-        .handleClick()
-
-      expect(
-        wrapper.instance().props.navigation.navigate
-      ).toHaveBeenCalledTimes(1)
     })
   })
   it('gives Select the proper value', () => {

--- a/src/screens/__tests__/FamilyParticipant.test.js
+++ b/src/screens/__tests__/FamilyParticipant.test.js
@@ -5,6 +5,7 @@ import Select from '../../components/Select'
 import DateInputComponent from '../../components/DateInput'
 import TextInput from '../../components/TextInput'
 import draft from '../__mocks__/draftMock.json'
+import StickyFooter from '../../components/StickyFooter'
 
 const createTestProps = props => ({
   t: value => value,
@@ -137,6 +138,11 @@ describe('Family Participant View', () => {
   })
 
   describe('rendering', () => {
+    it('renders the continue button with proper label', () => {
+      expect(wrapper.find(StickyFooter)).toHaveProp({
+        continueLabel: 'general.continue'
+      })
+    })
     it('renders TextInput', () => {
       expect(wrapper.find(TextInput)).toHaveLength(5)
     })
@@ -173,6 +179,16 @@ describe('Family Participant View', () => {
   })
 
   describe('functionality', () => {
+    it('calls navigator function on pressing Continue button', () => {
+      wrapper
+        .find(StickyFooter)
+        .props()
+        .handleClick()
+      expect(
+        wrapper.instance().props.navigation.navigate
+      ).toHaveBeenCalledTimes(1)
+    })
+
     it('calls addSurveyFamilyMemberData on input change', () => {
       wrapper
         .find(TextInput)

--- a/src/screens/__tests__/FamilyParticipant.test.js
+++ b/src/screens/__tests__/FamilyParticipant.test.js
@@ -1,10 +1,8 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { ScrollView } from 'react-native'
 import { FamilyParticipant } from '../lifemap/FamilyParticipant'
 import Select from '../../components/Select'
 import DateInputComponent from '../../components/DateInput'
-import Button from '../../components/Button'
 import TextInput from '../../components/TextInput'
 import draft from '../__mocks__/draftMock.json'
 
@@ -139,9 +137,6 @@ describe('Family Participant View', () => {
   })
 
   describe('rendering', () => {
-    it('renders base ScrollView', () => {
-      expect(wrapper.find(ScrollView)).toHaveLength(1)
-    })
     it('renders TextInput', () => {
       expect(wrapper.find(TextInput)).toHaveLength(5)
     })
@@ -150,9 +145,6 @@ describe('Family Participant View', () => {
     })
     it('renders DateInput', () => {
       expect(wrapper.find(DateInputComponent)).toHaveLength(1)
-    })
-    it('renders continue draft button', () => {
-      expect(wrapper.find(Button)).toHaveLength(1)
     })
 
     it('sets proper TextInput value from draft', () => {
@@ -207,16 +199,6 @@ describe('Family Participant View', () => {
         .onValidDate('January 21 1999')
       expect(
         wrapper.instance().props.addSurveyFamilyMemberData
-      ).toHaveBeenCalledTimes(1)
-    })
-
-    it('calls navigator function on pressing Continue button', () => {
-      wrapper
-        .find(Button)
-        .props()
-        .handleClick()
-      expect(
-        wrapper.instance().props.navigation.navigate
       ).toHaveBeenCalledTimes(1)
     })
 

--- a/src/screens/__tests__/Location.test.js
+++ b/src/screens/__tests__/Location.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { ScrollView } from 'react-native'
 import MapView from 'react-native-maps'
 import { Location } from '../lifemap/Location'
 import SearchBar from '../../components/SearchBar'
@@ -77,10 +76,6 @@ describe('Family Location component', () => {
     wrapper = shallow(<Location {...props} />)
   })
   describe('offline', () => {
-    it('renders base ScrollView', () => {
-      expect(wrapper.find(ScrollView)).toHaveLength(1)
-    })
-
     it('edits draft in field change', () => {
       wrapper
         .find('#postCode')
@@ -179,23 +174,6 @@ describe('Family Location component', () => {
     })
   })
 
-  it('navigates to SocioEconomicQuestion with proper params', () => {
-    wrapper
-      .find('#continue')
-      .props()
-      .handleClick()
-
-    expect(wrapper.instance().props.navigation.replace).toHaveBeenCalledWith(
-      'SocioEconomicQuestion',
-      {
-        draftId: 2,
-        survey: {
-          surveyId: 100,
-          surveyConfig: { surveyLocation: { country: 'BG' } }
-        }
-      }
-    )
-  })
   it('detects errors', () => {
     wrapper
       .find('#countrySelect')

--- a/src/screens/__tests__/Location.test.js
+++ b/src/screens/__tests__/Location.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme'
 import MapView from 'react-native-maps'
 import { Location } from '../lifemap/Location'
 import SearchBar from '../../components/SearchBar'
+import StickyFooter from '../../components/StickyFooter'
 
 // navigator mock
 /* eslint-disable no-undef */
@@ -74,6 +75,11 @@ describe('Family Location component', () => {
   beforeEach(() => {
     const props = createTestProps()
     wrapper = shallow(<Location {...props} />)
+  })
+  it('renders the continue button with proper label', () => {
+    expect(wrapper.find(StickyFooter)).toHaveProp({
+      continueLabel: 'general.continue'
+    })
   })
   describe('offline', () => {
     it('edits draft in field change', () => {
@@ -281,5 +287,23 @@ describe('Render optimization', () => {
 
   it('country select has preselected default country', () => {
     expect(wrapper.find('#countrySelect')).toHaveProp({ value: 'BG' })
+  })
+
+  it('navigates to SocioEconomicQuestion with proper params', () => {
+    wrapper
+      .find(StickyFooter)
+      .props()
+      .handleClick()
+
+    expect(wrapper.instance().props.navigation.replace).toHaveBeenCalledWith(
+      'SocioEconomicQuestion',
+      {
+        draftId: 2,
+        survey: {
+          surveyId: 100,
+          surveyConfig: { surveyLocation: { country: 'BG' } }
+        }
+      }
+    )
   })
 })

--- a/src/screens/__tests__/Skipped.test.js
+++ b/src/screens/__tests__/Skipped.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme'
 import { Image, FlatList } from 'react-native'
 import { Skipped } from '../lifemap/Skipped'
 import Tip from '../../components/Tip'
+import StickyFooter from '../../components/StickyFooter'
 
 const createTestProps = props => ({
   t: value => value,
@@ -48,6 +49,11 @@ describe('Skipped Questions View when questions are skipped', () => {
     wrapper = shallow(<Skipped {...props} />)
   })
   describe('rendering', () => {
+    it('renders the continue button with proper label', () => {
+      expect(wrapper.find(StickyFooter)).toHaveProp({
+        continueLabel: 'general.continue'
+      })
+    })
     it('renders Image', () => {
       expect(wrapper.find(Image)).toHaveLength(1)
     })
@@ -60,6 +66,15 @@ describe('Skipped Questions View when questions are skipped', () => {
     })
   })
   describe('functionality', () => {
+    it('calls navigator function on pressing Continue button', () => {
+      wrapper
+        .find(StickyFooter)
+        .props()
+        .handleClick()
+      expect(
+        wrapper.instance().props.navigation.navigate
+      ).toHaveBeenCalledTimes(1)
+    })
     it('passess the correct data to FlatList', () => {
       expect(wrapper.find(FlatList).props().data).toEqual([
         { key: 'phoneNumber', value: 0 }

--- a/src/screens/__tests__/Skipped.test.js
+++ b/src/screens/__tests__/Skipped.test.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { ScrollView, Image, FlatList } from 'react-native'
+import { Image, FlatList } from 'react-native'
 import { Skipped } from '../lifemap/Skipped'
-import Button from '../../components/Button'
 import Tip from '../../components/Tip'
 
 const createTestProps = props => ({
@@ -49,9 +48,6 @@ describe('Skipped Questions View when questions are skipped', () => {
     wrapper = shallow(<Skipped {...props} />)
   })
   describe('rendering', () => {
-    it('renders ScrollView', () => {
-      expect(wrapper.find(ScrollView)).toHaveLength(1)
-    })
     it('renders Image', () => {
       expect(wrapper.find(Image)).toHaveLength(1)
     })
@@ -62,25 +58,12 @@ describe('Skipped Questions View when questions are skipped', () => {
     it('renders Tip', () => {
       expect(wrapper.find(Tip)).toHaveLength(1)
     })
-    it('renders Button', () => {
-      expect(wrapper.find(Button)).toHaveLength(1)
-    })
   })
   describe('functionality', () => {
     it('passess the correct data to FlatList', () => {
       expect(wrapper.find(FlatList).props().data).toEqual([
         { key: 'phoneNumber', value: 0 }
       ])
-    })
-
-    it('calls navigation', () => {
-      wrapper
-        .find(Button)
-        .props()
-        .handleClick()
-      expect(
-        wrapper.instance().props.navigation.navigate
-      ).toHaveBeenCalledTimes(1)
     })
   })
   describe('Render optimization', () => {

--- a/src/screens/__tests__/SocioEconomicQuestion.test.js
+++ b/src/screens/__tests__/SocioEconomicQuestion.test.js
@@ -4,6 +4,7 @@ import { SocioEconomicQuestion } from '../lifemap/SocioEconomicQuestion'
 import Select from '../../components/Select'
 import TextInput from '../../components/TextInput'
 import data from '../__mocks__/fake-socio-economic-data.json'
+import StickyFooter from '../../components/StickyFooter'
 
 const createTestProps = props => ({
   t: value => value,
@@ -110,6 +111,27 @@ describe('SocioEconomicQuestion screens', () => {
       wrapper = shallow(<SocioEconomicQuestion {...props} />)
     })
 
+    it('renders the continue button with proper label', () => {
+      expect(wrapper.find(StickyFooter)).toHaveProp({
+        continueLabel: 'general.continue'
+      })
+    })
+
+    it('navigates to next socio-economics screen on pressing continue', () => {
+      wrapper
+        .find(StickyFooter)
+        .last()
+        .props()
+        .handleClick()
+
+      expect(wrapper.instance().props.navigation.push).toHaveBeenCalledTimes(1)
+
+      expect(wrapper.instance().props.navigation.push).toHaveBeenCalledWith(
+        'SocioEconomicQuestion',
+        expect.any(Object)
+      )
+    })
+
     it('renders Select elements for each select question', () => {
       expect(wrapper.find(Select)).toHaveLength(2)
     })
@@ -200,6 +222,23 @@ describe('SocioEconomicQuestion screens', () => {
         placeholder:
           'Please estimate your gross monthly household income (i.e, before taxes National Insurance contributions or other deductions)'
       })
+    })
+
+    it('navigates to next non-socio-economic screen after done with all questions', () => {
+      wrapper
+        .find(StickyFooter)
+        .last()
+        .props()
+        .handleClick()
+
+      expect(
+        wrapper.instance().props.navigation.navigate
+      ).toHaveBeenCalledTimes(1)
+
+      expect(wrapper.instance().props.navigation.navigate).toHaveBeenCalledWith(
+        'BeginLifemap',
+        expect.any(Object)
+      )
     })
   })
 })

--- a/src/screens/__tests__/SocioEconomicQuestion.test.js
+++ b/src/screens/__tests__/SocioEconomicQuestion.test.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import { SocioEconomicQuestion } from '../lifemap/SocioEconomicQuestion'
 import Select from '../../components/Select'
-import Button from '../../components/Button'
 import TextInput from '../../components/TextInput'
 import data from '../__mocks__/fake-socio-economic-data.json'
 
@@ -132,30 +131,6 @@ describe('SocioEconomicQuestion screens', () => {
       })
     })
 
-    it('renders a continue button', () => {
-      expect(wrapper.find(Button)).toHaveLength(1)
-
-      expect(wrapper.find(Button).last()).toHaveProp({
-        colored: true,
-        text: 'general.continue'
-      })
-    })
-
-    it('navigates to next socio-economics screen on pressing continue', () => {
-      wrapper
-        .find(Button)
-        .last()
-        .props()
-        .handleClick()
-
-      expect(wrapper.instance().props.navigation.push).toHaveBeenCalledTimes(1)
-
-      expect(wrapper.instance().props.navigation.push).toHaveBeenCalledWith(
-        'SocioEconomicQuestion',
-        expect.any(Object)
-      )
-    })
-
     it('calls addDraftProgress on mount', () => {
       expect(wrapper.instance().props.addDraftProgress).toHaveBeenCalledTimes(1)
     })
@@ -225,23 +200,6 @@ describe('SocioEconomicQuestion screens', () => {
         placeholder:
           'Please estimate your gross monthly household income (i.e, before taxes National Insurance contributions or other deductions)'
       })
-    })
-
-    it('navigates to next non-socio-economic screen after done with all questions', () => {
-      wrapper
-        .find(Button)
-        .last()
-        .props()
-        .handleClick()
-
-      expect(
-        wrapper.instance().props.navigation.navigate
-      ).toHaveBeenCalledTimes(1)
-
-      expect(wrapper.instance().props.navigation.navigate).toHaveBeenCalledWith(
-        'BeginLifemap',
-        expect.any(Object)
-      )
     })
   })
 })

--- a/src/screens/lifemap/AddAchievement.js
+++ b/src/screens/lifemap/AddAchievement.js
@@ -1,16 +1,14 @@
 import React, { Component } from 'react'
-import { ScrollView, StyleSheet, View, Text } from 'react-native'
+import { View, Text } from 'react-native'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import { Divider } from 'react-native-elements'
 import { withNamespaces } from 'react-i18next'
-
+import StickyFooter from '../../components/StickyFooter'
 import { addSurveyPriorityAcheivementData } from '../../redux/actions'
-
 import globalStyles from '../../globalStyles'
 import colors from '../../theme.json'
-import Button from '../../components/Button'
 import TextInput from '../../components/TextInput'
 
 export class AddAchievement extends Component {
@@ -81,76 +79,59 @@ export class AddAchievement extends Component {
     const achievement = this.getAchievementValue(draft)
 
     return (
-      <ScrollView
-        style={globalStyles.background}
-        contentContainerStyle={styles.contentContainer}
+      <StickyFooter
+        continueLabel={t('general.save')}
+        handleClick={this.addAchievement}
       >
-        <View>
-          <View style={globalStyles.container}>
-            <Text style={globalStyles.h2}>
-              {this.props.navigation.getParam('indicatorText')}
-            </Text>
-            <Divider
-              style={{ backgroundColor: colors.palegrey, marginVertical: 10 }}
+        <View style={globalStyles.container}>
+          <Text style={globalStyles.h2}>
+            {this.props.navigation.getParam('indicatorText')}
+          </Text>
+          <Divider
+            style={{ backgroundColor: colors.palegrey, marginVertical: 10 }}
+          />
+          <View
+            style={{
+              flexDirection: 'row'
+            }}
+          >
+            <Icon
+              name="stars"
+              color={colors.blue}
+              size={17}
+              style={{ marginRight: 10, marginLeft: -10 }}
             />
-            <View
-              style={{
-                flexDirection: 'row'
-              }}
-            >
-              <Icon
-                name="stars"
-                color={colors.blue}
-                size={17}
-                style={{ marginRight: 10, marginLeft: -10 }}
-              />
-              <Text style={globalStyles.h3}>
-                {t('views.lifemap.achievement')}
-              </Text>
-            </View>
+            <Text style={globalStyles.h3}>
+              {t('views.lifemap.achievement')}
+            </Text>
           </View>
-          <TextInput
-            field="action"
-            required
-            showErrors={showErrors}
-            detectError={this.detectError}
-            onChangeText={text => this.setState({ action: text })}
-            placeholder={
-              this.state.action ? '' : t('views.lifemap.writeYourAnswerHere')
-            }
-            label={t('views.lifemap.howDidYouGetIt')}
-            value={achievement ? achievement.action : ''}
-            multiline
-          />
-          <TextInput
-            label={t('views.lifemap.whatDidItTakeToAchieveThis')}
-            onChangeText={text => this.setState({ roadmap: text })}
-            placeholder={
-              this.state.roadmap ? '' : t('views.lifemap.writeYourAnswerHere')
-            }
-            value={achievement ? achievement.roadmap : ''}
-            multiline
-          />
         </View>
-        <View style={{ height: 50 }}>
-          <Button
-            id="save"
-            colored
-            text={t('general.save')}
-            handleClick={() => this.addAchievement()}
-          />
-        </View>
-      </ScrollView>
+        <TextInput
+          field="action"
+          required
+          showErrors={showErrors}
+          detectError={this.detectError}
+          onChangeText={text => this.setState({ action: text })}
+          placeholder={
+            this.state.action ? '' : t('views.lifemap.writeYourAnswerHere')
+          }
+          label={t('views.lifemap.howDidYouGetIt')}
+          value={achievement ? achievement.action : ''}
+          multiline
+        />
+        <TextInput
+          label={t('views.lifemap.whatDidItTakeToAchieveThis')}
+          onChangeText={text => this.setState({ roadmap: text })}
+          placeholder={
+            this.state.roadmap ? '' : t('views.lifemap.writeYourAnswerHere')
+          }
+          value={achievement ? achievement.roadmap : ''}
+          multiline
+        />
+      </StickyFooter>
     )
   }
 }
-const styles = StyleSheet.create({
-  contentContainer: {
-    flexGrow: 1,
-    flexDirection: 'column',
-    justifyContent: 'space-between'
-  }
-})
 
 AddAchievement.propTypes = {
   t: PropTypes.func.isRequired,

--- a/src/screens/lifemap/AddPriority.js
+++ b/src/screens/lifemap/AddPriority.js
@@ -1,15 +1,14 @@
 import React, { Component } from 'react'
-import { ScrollView, StyleSheet, View, Text } from 'react-native'
+import { View, Text } from 'react-native'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 import { Divider } from 'react-native-elements'
 import { withNamespaces } from 'react-i18next'
 import { addSurveyPriorityAcheivementData } from '../../redux/actions'
-
+import StickyFooter from '../../components/StickyFooter'
 import globalStyles from '../../globalStyles'
 import colors from '../../theme.json'
-import Button from '../../components/Button'
 import TextInput from '../../components/TextInput'
 import Counter from '../../components/Counter'
 
@@ -80,80 +79,64 @@ export class AddPriority extends Component {
     const priority = this.getPriorityValue(draft)
 
     return (
-      <ScrollView
-        style={globalStyles.background}
-        contentContainerStyle={styles.contentContainer}
+      <StickyFooter
+        continueLabel={t('general.save')}
+        handleClick={this.addPriority}
       >
-        <View>
-          <View style={globalStyles.container}>
-            <Text style={globalStyles.h2}>
-              {this.props.navigation.getParam('indicatorText')}
-            </Text>
-            <Divider
-              style={{ backgroundColor: colors.palegrey, marginVertical: 10 }}
-            />
-            <View
-              style={{
-                flexDirection: 'row'
-              }}
-            >
-              <Icon
-                name="pin"
-                color={colors.blue}
-                size={17}
-                style={{ marginRight: 10, marginLeft: -10 }}
-              />
-              <Text style={globalStyles.h3}>{t('views.lifemap.priority')}</Text>
-            </View>
-          </View>
-          <TextInput
-            onChangeText={text => this.setState({ reason: text })}
-            placeholder={reason ? '' : t('views.lifemap.writeYourAnswerHere')}
-            label={t('views.lifemap.whyDontYouHaveIt')}
-            value={priority ? priority.reason : ''}
-            multiline
+        <View style={globalStyles.container}>
+          <Text style={globalStyles.h2}>
+            {this.props.navigation.getParam('indicatorText')}
+          </Text>
+          <Divider
+            style={{ backgroundColor: colors.palegrey, marginVertical: 10 }}
           />
-          <TextInput
-            label={t('views.lifemap.whatWillYouDoToGetIt')}
-            onChangeText={text => this.setState({ action: text })}
-            placeholder={action ? '' : t('views.lifemap.writeYourAnswerHere')}
-            value={priority ? priority.action : ''}
-            multiline
-          />
-          <View style={{ padding: 15 }}>
-            <Counter
-              editCounter={this.editCounter}
-              count={estimatedDate}
-              text={t('views.lifemap.howManyMonthsWillItTake')}
+          <View
+            style={{
+              flexDirection: 'row'
+            }}
+          >
+            <Icon
+              name="pin"
+              color={colors.blue}
+              size={17}
+              style={{ marginRight: 10, marginLeft: -10 }}
             />
+            <Text style={globalStyles.h3}>{t('views.lifemap.priority')}</Text>
           </View>
-          {/* Error message */}
-          {validationError ? (
-            <Text style={{ paddingHorizontal: 15, color: colors.red }}>
-              {t('validation.fieldIsRequired')}
-            </Text>
-          ) : (
-            <View />
-          )}
         </View>
-        <View style={{ height: 50 }}>
-          <Button
-            colored
-            text={t('general.save')}
-            handleClick={() => this.addPriority()}
+        <TextInput
+          onChangeText={text => this.setState({ reason: text })}
+          placeholder={reason ? '' : t('views.lifemap.writeYourAnswerHere')}
+          label={t('views.lifemap.whyDontYouHaveIt')}
+          value={priority ? priority.reason : ''}
+          multiline
+        />
+        <TextInput
+          label={t('views.lifemap.whatWillYouDoToGetIt')}
+          onChangeText={text => this.setState({ action: text })}
+          placeholder={action ? '' : t('views.lifemap.writeYourAnswerHere')}
+          value={priority ? priority.action : ''}
+          multiline
+        />
+        <View style={{ padding: 15 }}>
+          <Counter
+            editCounter={this.editCounter}
+            count={estimatedDate}
+            text={t('views.lifemap.howManyMonthsWillItTake')}
           />
         </View>
-      </ScrollView>
+        {/* Error message */}
+        {validationError ? (
+          <Text style={{ paddingHorizontal: 15, color: colors.red }}>
+            {t('validation.fieldIsRequired')}
+          </Text>
+        ) : (
+          <View />
+        )}
+      </StickyFooter>
     )
   }
 }
-const styles = StyleSheet.create({
-  contentContainer: {
-    flexGrow: 1,
-    flexDirection: 'column',
-    justifyContent: 'space-between'
-  }
-})
 
 AddPriority.propTypes = {
   t: PropTypes.func.isRequired,

--- a/src/screens/lifemap/FamilyMembersBirthdates.js
+++ b/src/screens/lifemap/FamilyMembersBirthdates.js
@@ -1,16 +1,14 @@
 import React, { Component } from 'react'
-import { ScrollView, StyleSheet, View, Text } from 'react-native'
+import { View, Text } from 'react-native'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { withNamespaces } from 'react-i18next'
-
+import StickyFooter from '../../components/StickyFooter'
 import {
   addSurveyFamilyMemberData,
   addDraftProgress
 } from '../../redux/actions'
-
 import globalStyles from '../../globalStyles'
-import Button from '../../components/Button'
 import DateInputComponent from '../../components/DateInput'
 
 export class FamilyMembersBirthdates extends Component {
@@ -53,7 +51,7 @@ export class FamilyMembersBirthdates extends Component {
     })
   }
 
-  handleClick() {
+  handleClick = () => {
     this.props.navigation.navigate('Location', {
       draftId: this.draftId,
       survey: this.survey
@@ -84,55 +82,37 @@ export class FamilyMembersBirthdates extends Component {
     )[0]
 
     return (
-      <ScrollView
-        style={globalStyles.background}
-        contentContainerStyle={styles.contentContainer}
+      <StickyFooter
+        handleClick={this.handleClick}
+        continueLabel={t('general.continue')}
       >
-        <View style={{ ...globalStyles.container, padding: 0 }}>
-          {draft.familyData.familyMembersList.slice(1).map((item, i) => (
-            <View key={i}>
-              <Text
-                style={{
-                  ...globalStyles.h3,
-                  paddingHorizontal: 20,
-                  marginTop: 15,
-                  marginBottom: -30
-                }}
-              >
-                {item.firstName}
-              </Text>
-              <DateInputComponent
-                field={i.toString()}
-                detectError={this.detectError}
-                onValidDate={date => this.addFamilyMemberBirthdate(date, i + 1)}
-                value={
-                  (this.getFieldValue(draft, 'familyMembersList')[i + 1] || {})
-                    .birthDate
-                }
-              />
-            </View>
-          ))}
-        </View>
-
-        <View style={{ height: 50, marginTop: 30 }}>
-          <Button
-            disabled={!!this.errorsDetected.length}
-            colored
-            text={t('general.continue')}
-            handleClick={() => this.handleClick()}
-          />
-        </View>
-      </ScrollView>
+        {draft.familyData.familyMembersList.slice(1).map((item, i) => (
+          <View key={i}>
+            <Text
+              style={{
+                ...globalStyles.h3,
+                paddingHorizontal: 20,
+                marginTop: 15,
+                marginBottom: -30
+              }}
+            >
+              {item.firstName}
+            </Text>
+            <DateInputComponent
+              field={i.toString()}
+              detectError={this.detectError}
+              onValidDate={date => this.addFamilyMemberBirthdate(date, i + 1)}
+              value={
+                (this.getFieldValue(draft, 'familyMembersList')[i + 1] || {})
+                  .birthDate
+              }
+            />
+          </View>
+        ))}
+      </StickyFooter>
     )
   }
 }
-const styles = StyleSheet.create({
-  contentContainer: {
-    flexGrow: 1,
-    flexDirection: 'column',
-    justifyContent: 'space-between'
-  }
-})
 
 FamilyMembersBirthdates.propTypes = {
   t: PropTypes.func.isRequired,

--- a/src/screens/lifemap/FamilyMembersGender.js
+++ b/src/screens/lifemap/FamilyMembersGender.js
@@ -1,16 +1,14 @@
 import React, { Component } from 'react'
-import { ScrollView, StyleSheet, View, Text } from 'react-native'
+import { View, Text } from 'react-native'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { withNamespaces } from 'react-i18next'
-
+import StickyFooter from '../../components/StickyFooter'
 import {
   addSurveyFamilyMemberData,
   addDraftProgress
 } from '../../redux/actions'
-
 import globalStyles from '../../globalStyles'
-import Button from '../../components/Button'
 import Select from '../../components/Select'
 
 export class FamilyMembersGender extends Component {
@@ -53,7 +51,7 @@ export class FamilyMembersGender extends Component {
     })
   }
 
-  handleClick() {
+  handleClick = () => {
     this.props.navigation.navigate('FamilyMembersBirthdates', {
       draftId: this.draftId,
       survey: this.survey
@@ -85,57 +83,39 @@ export class FamilyMembersGender extends Component {
     )[0]
 
     return (
-      <ScrollView
-        style={globalStyles.background}
-        contentContainerStyle={styles.contentContainer}
+      <StickyFooter
+        handleClick={this.handleClick}
+        continueLabel={t('general.continue')}
       >
-        <View style={{ ...globalStyles.container, padding: 0 }}>
-          {draft.familyData.familyMembersList.slice(1).map((item, i) => (
-            <View key={i}>
-              <Text
-                style={{
-                  ...globalStyles.h3,
-                  paddingHorizontal: 20,
-                  marginTop: 15
-                }}
-              >
-                {item.firstName}
-              </Text>
-              <Select
-                field={i.toString()}
-                onChange={text => this.addFamilyMemberGender(text, i + 1)}
-                label={t('views.family.gender')}
-                placeholder={t('views.family.selectGender')}
-                value={
-                  (this.getFieldValue(draft, 'familyMembersList')[i + 1] || {})
-                    .gender || ''
-                }
-                detectError={this.detectError}
-                options={this.gender}
-              />
-            </View>
-          ))}
-        </View>
-
-        <View style={{ height: 50, marginTop: 30 }}>
-          <Button
-            disabled={!!this.errorsDetected.length}
-            colored
-            text={t('general.continue')}
-            handleClick={() => this.handleClick()}
-          />
-        </View>
-      </ScrollView>
+        {draft.familyData.familyMembersList.slice(1).map((item, i) => (
+          <View key={i}>
+            <Text
+              style={{
+                ...globalStyles.h3,
+                paddingHorizontal: 20,
+                marginTop: 15
+              }}
+            >
+              {item.firstName}
+            </Text>
+            <Select
+              field={i.toString()}
+              onChange={text => this.addFamilyMemberGender(text, i + 1)}
+              label={t('views.family.gender')}
+              placeholder={t('views.family.selectGender')}
+              value={
+                (this.getFieldValue(draft, 'familyMembersList')[i + 1] || {})
+                  .gender || ''
+              }
+              detectError={this.detectError}
+              options={this.gender}
+            />
+          </View>
+        ))}
+      </StickyFooter>
     )
   }
 }
-const styles = StyleSheet.create({
-  contentContainer: {
-    flexGrow: 1,
-    flexDirection: 'column',
-    justifyContent: 'space-between'
-  }
-})
 
 FamilyMembersGender.propTypes = {
   t: PropTypes.func.isRequired,

--- a/src/screens/lifemap/FamilyMembersNames.js
+++ b/src/screens/lifemap/FamilyMembersNames.js
@@ -1,18 +1,14 @@
 import React, { Component } from 'react'
-import { ScrollView, StyleSheet, View } from 'react-native'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { withNamespaces } from 'react-i18next'
-
 import {
   addSurveyData,
   addSurveyFamilyMemberData,
   removeFamilyMembers,
   addDraftProgress
 } from '../../redux/actions'
-
-import globalStyles from '../../globalStyles'
-import Button from '../../components/Button'
+import StickyFooter from '../../components/StickyFooter'
 import Select from '../../components/Select'
 import TextInput from '../../components/TextInput'
 
@@ -55,7 +51,7 @@ export class FamilyMembersNames extends Component {
     })
   }
 
-  handleClick() {
+  handleClick = () => {
     if (this.state.errorsDetected.length) {
       this.setState({
         showErrors: true
@@ -153,72 +149,55 @@ export class FamilyMembersNames extends Component {
         : []
 
     return (
-      <ScrollView
-        style={globalStyles.background}
-        contentContainerStyle={styles.contentContainer}
+      <StickyFooter
+        handleClick={() => this.handleClick(draft)}
+        continueLabel={t('general.continue')}
       >
-        <View style={{ ...globalStyles.container, padding: 0 }}>
-          <Select
-            id="familyMembersCount"
-            required
-            onChange={this.addFamilyCount}
-            label={t('views.family.peopleLivingInThisHousehold')}
-            placeholder={t('views.family.peopleLivingInThisHousehold')}
-            field="countFamilyMembers"
-            value={this.getFieldValue('countFamilyMembers') || ''}
-            detectError={this.detectError}
-            showErrors={showErrors}
-            options={this.getFamilyMembersCountArray(t)}
-          />
+        <Select
+          id="familyMembersCount"
+          required
+          onChange={this.addFamilyCount}
+          label={t('views.family.peopleLivingInThisHousehold')}
+          placeholder={t('views.family.peopleLivingInThisHousehold')}
+          field="countFamilyMembers"
+          value={this.getFieldValue('countFamilyMembers') || ''}
+          detectError={this.detectError}
+          showErrors={showErrors}
+          options={this.getFamilyMembersCountArray(t)}
+        />
+        <TextInput
+          validation="string"
+          field=""
+          onChangeText={() => {}}
+          placeholder={`${t('views.family.familyMember')} 1 - ${t(
+            'views.family.participant'
+          )}`}
+          value={draft.familyData.familyMembersList[0].firstName}
+          required
+          readonly
+          detectError={this.detectError}
+          showErrors={showErrors}
+        />
+        {familyMembersCount.map((item, i) => (
           <TextInput
+            key={i}
             validation="string"
-            field=""
-            onChangeText={() => {}}
-            placeholder={`${t('views.family.familyMember')} 1 - ${t(
-              'views.family.participant'
-            )}`}
-            value={draft.familyData.familyMembersList[0].firstName}
+            field={i.toString()}
+            onChangeText={text => this.addFamilyMemberName(text, i + 1)}
+            placeholder={`${t('views.family.familyMember')} ${i + 2}`}
+            value={
+              (this.getFieldValue('familyMembersList')[i + 1] || {})
+                .firstName || ''
+            }
             required
-            readonly
             detectError={this.detectError}
             showErrors={showErrors}
           />
-          {familyMembersCount.map((item, i) => (
-            <TextInput
-              key={i}
-              validation="string"
-              field={i.toString()}
-              onChangeText={text => this.addFamilyMemberName(text, i + 1)}
-              placeholder={`${t('views.family.familyMember')} ${i + 2}`}
-              value={
-                (this.getFieldValue('familyMembersList')[i + 1] || {})
-                  .firstName || ''
-              }
-              required
-              detectError={this.detectError}
-              showErrors={showErrors}
-            />
-          ))}
-        </View>
-
-        <View style={{ height: 50, marginTop: 30 }}>
-          <Button
-            colored
-            text={t('general.continue')}
-            handleClick={() => this.handleClick(draft)}
-          />
-        </View>
-      </ScrollView>
+        ))}
+      </StickyFooter>
     )
   }
 }
-const styles = StyleSheet.create({
-  contentContainer: {
-    flexGrow: 1,
-    flexDirection: 'column',
-    justifyContent: 'space-between'
-  }
-})
 
 FamilyMembersNames.propTypes = {
   drafts: PropTypes.array,

--- a/src/screens/lifemap/FamilyParticipant.js
+++ b/src/screens/lifemap/FamilyParticipant.js
@@ -1,8 +1,7 @@
 import React, { Component } from 'react'
-import { StyleSheet, ScrollView, View } from 'react-native'
+import { StyleSheet } from 'react-native'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
-
 import uuid from 'uuid/v1'
 import {
   createDraft,
@@ -11,12 +10,10 @@ import {
 } from '../../redux/actions'
 import { withNamespaces } from 'react-i18next'
 import Icon from 'react-native-vector-icons/MaterialIcons'
-
+import StickyFooter from '../../components/StickyFooter'
 import Select from '../../components/Select'
-import Button from '../../components/Button'
 import TextInput from '../../components/TextInput'
 import DateInputComponent from '../../components/DateInput'
-import globalStyles from '../../globalStyles'
 import colors from '../../theme.json'
 
 export class FamilyParticipant extends Component {
@@ -81,7 +78,7 @@ export class FamilyParticipant extends Component {
     this.props.navigation.setParams({ draftId: this.draftId })
   }
 
-  handleClick() {
+  handleClick = () => {
     if (this.errorsDetected.length) {
       this.setState({
         showErrors: true
@@ -126,130 +123,111 @@ export class FamilyParticipant extends Component {
       draft => draft.draftId === this.draftId
     )[0]
     return (
-      <ScrollView
-        style={globalStyles.background}
-        contentContainerStyle={styles.contentContainer}
+      <StickyFooter
+        handleClick={this.handleClick}
+        continueLabel={t('general.continue')}
       >
-        <View
-          style={{
-            ...globalStyles.container,
-            padding: 0
-          }}
-        >
-          <Icon name="face" color={colors.grey} size={55} style={styles.icon} />
-          <TextInput
-            validation="string"
-            field="firstName"
-            onChangeText={this.addSurveyData}
-            placeholder={t('views.family.firstName')}
-            value={this.getFieldValue(draft, 'firstName') || ''}
-            required
-            detectError={this.detectError}
-            showErrors={showErrors}
-          />
-          <TextInput
-            field="lastName"
-            validation="string"
-            onChangeText={this.addSurveyData}
-            placeholder={t('views.family.lastName')}
-            value={this.getFieldValue(draft, 'lastName') || ''}
-            required
-            detectError={this.detectError}
-            showErrors={showErrors}
-          />
-          <Select
-            id="gender"
-            required
-            onChange={this.addSurveyData}
-            label={t('views.family.gender')}
-            placeholder={t('views.family.selectGender')}
-            field="gender"
-            value={this.getFieldValue(draft, 'gender') || ''}
-            detectError={this.detectError}
-            showErrors={showErrors}
-            options={this.gender}
-          />
+        <Icon name="face" color={colors.grey} size={55} style={styles.icon} />
+        <TextInput
+          validation="string"
+          field="firstName"
+          onChangeText={this.addSurveyData}
+          placeholder={t('views.family.firstName')}
+          value={this.getFieldValue(draft, 'firstName') || ''}
+          required
+          detectError={this.detectError}
+          showErrors={showErrors}
+        />
+        <TextInput
+          field="lastName"
+          validation="string"
+          onChangeText={this.addSurveyData}
+          placeholder={t('views.family.lastName')}
+          value={this.getFieldValue(draft, 'lastName') || ''}
+          required
+          detectError={this.detectError}
+          showErrors={showErrors}
+        />
+        <Select
+          id="gender"
+          required
+          onChange={this.addSurveyData}
+          label={t('views.family.gender')}
+          placeholder={t('views.family.selectGender')}
+          field="gender"
+          value={this.getFieldValue(draft, 'gender') || ''}
+          detectError={this.detectError}
+          showErrors={showErrors}
+          options={this.gender}
+        />
 
-          <DateInputComponent
-            required
-            label={t('views.family.dateOfBirth')}
-            field="birthDate"
-            detectError={this.detectError}
-            showErrors={showErrors}
-            onValidDate={this.addSurveyData}
-            value={this.getFieldValue(draft, 'birthDate')}
-          />
+        <DateInputComponent
+          required
+          label={t('views.family.dateOfBirth')}
+          field="birthDate"
+          detectError={this.detectError}
+          showErrors={showErrors}
+          onValidDate={this.addSurveyData}
+          value={this.getFieldValue(draft, 'birthDate')}
+        />
 
-          <Select
-            required
-            onChange={this.addSurveyData}
-            label={t('views.family.documentType')}
-            placeholder={t('views.family.documentType')}
-            field="documentType"
-            value={this.getFieldValue(draft, 'documentType') || ''}
-            detectError={this.detectError}
-            showErrors={showErrors}
-            options={this.documentType}
-          />
-          <TextInput
-            onChangeText={this.addSurveyData}
-            field="documentNumber"
-            required
-            value={this.getFieldValue(draft, 'documentNumber')}
-            placeholder={t('views.family.documentNumber')}
-            detectError={this.detectError}
-            showErrors={showErrors}
-          />
-          <Select
-            required
-            onChange={this.addSurveyData}
-            label={t('views.family.countryOfBirth')}
-            countrySelect
-            country={this.survey.surveyConfig.surveyLocation.country}
-            placeholder={t('views.family.selectACountry')}
-            field="birthCountry"
-            value={this.getFieldValue(draft, 'birthCountry') || ''}
-            detectError={this.detectError}
-            showErrors={showErrors}
-          />
-          <TextInput
-            onChangeText={this.addSurveyData}
-            field="email"
-            value={this.getFieldValue(draft, 'email')}
-            placeholder={t('views.family.email')}
-            validation="email"
-            detectError={this.detectError}
-            showErrors={showErrors}
-          />
-          <TextInput
-            onChangeText={this.addSurveyData}
-            field="phoneNumber"
-            value={this.getFieldValue(draft, 'phoneNumber')}
-            placeholder={t('views.family.phone')}
-            validation="phoneNumber"
-            detectError={this.detectError}
-            showErrors={showErrors}
-          />
-        </View>
-        <View style={{ height: 50, marginTop: 50 }}>
-          <Button
-            colored
-            text={t('general.continue')}
-            handleClick={() => this.handleClick()}
-          />
-        </View>
-      </ScrollView>
+        <Select
+          required
+          onChange={this.addSurveyData}
+          label={t('views.family.documentType')}
+          placeholder={t('views.family.documentType')}
+          field="documentType"
+          value={this.getFieldValue(draft, 'documentType') || ''}
+          detectError={this.detectError}
+          showErrors={showErrors}
+          options={this.documentType}
+        />
+        <TextInput
+          onChangeText={this.addSurveyData}
+          field="documentNumber"
+          required
+          value={this.getFieldValue(draft, 'documentNumber')}
+          placeholder={t('views.family.documentNumber')}
+          detectError={this.detectError}
+          showErrors={showErrors}
+        />
+        <Select
+          required
+          onChange={this.addSurveyData}
+          label={t('views.family.countryOfBirth')}
+          countrySelect
+          country={this.survey.surveyConfig.surveyLocation.country}
+          placeholder={t('views.family.selectACountry')}
+          field="birthCountry"
+          value={this.getFieldValue(draft, 'birthCountry') || ''}
+          detectError={this.detectError}
+          showErrors={showErrors}
+        />
+        <TextInput
+          onChangeText={this.addSurveyData}
+          field="email"
+          value={this.getFieldValue(draft, 'email')}
+          placeholder={t('views.family.email')}
+          validation="email"
+          detectError={this.detectError}
+          showErrors={showErrors}
+        />
+        <TextInput
+          onChangeText={this.addSurveyData}
+          field="phoneNumber"
+          value={this.getFieldValue(draft, 'phoneNumber')}
+          placeholder={t('views.family.phone')}
+          validation="phoneNumber"
+          detectError={this.detectError}
+          showErrors={showErrors}
+        />
+      </StickyFooter>
     )
   }
 }
 const styles = StyleSheet.create({
   icon: {
     alignSelf: 'center'
-  },
-  contentContainer: {
-    flexGrow: 1,
-    flexDirection: 'column',
-    justifyContent: 'space-between'
   }
 })
 

--- a/src/screens/lifemap/Location.js
+++ b/src/screens/lifemap/Location.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import {
-  ScrollView,
   View,
   StyleSheet,
   ActivityIndicator,
@@ -13,9 +12,8 @@ import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import MapView from 'react-native-maps'
 import { withNamespaces } from 'react-i18next'
-
+import StickyFooter from '../../components/StickyFooter'
 import { addSurveyData, addDraftProgress } from '../../redux/actions'
-import Button from '../../components/Button'
 import TextInput from '../../components/TextInput'
 import globalStyles from '../../globalStyles'
 import colors from '../../theme.json'
@@ -265,163 +263,148 @@ export class Location extends Component {
     const draft = this.getDraft()
 
     return (
-      <ScrollView
-        style={globalStyles.background}
-        contentContainerStyle={styles.contentContainer}
+      <StickyFooter
+        handleClick={this.handleClick}
+        continueLabel={t('general.continue')}
       >
         <View>
-          <View>
-            {showMap && isOnline ? (
-              <View>
-                <View pointerEvents="none" style={styles.fakeMarker}>
-                  <Image source={marker} />
-                </View>
-                <SearchBar
-                  id="searchAddress"
-                  style={styles.search}
-                  placeholder={t('views.family.searchByStreetOrPostalCode')}
-                  onChangeText={searchAddress =>
-                    this.setState({ searchAddress })
-                  }
-                  onSubmit={this.searcForAddress}
-                  value={searchAddress}
-                />
-                <MapView
-                  ref={ref => {
-                    this.map = ref
-                  }}
-                  style={styles.map}
-                  initialRegion={{
-                    latitude,
-                    longitude,
-                    latitudeDelta,
-                    longitudeDelta
-                  }}
-                  region={{
-                    latitude,
-                    longitude,
-                    latitudeDelta,
-                    longitudeDelta
-                  }}
-                  onRegionChangeComplete={this.onDragMap}
-                />
-                {centeringMap ? (
-                  <ActivityIndicator
-                    style={styles.center}
-                    size={54}
-                    color={colors.palegreen}
-                  />
-                ) : (
-                  <TouchableOpacity
-                    id="centerMap"
-                    style={styles.center}
-                    onPress={this.getDeviceLocation}
-                  >
-                    <Image source={center} style={{ width: 21, height: 21 }} />
-                  </TouchableOpacity>
-                )}
+          {showMap && isOnline ? (
+            <View>
+              <View pointerEvents="none" style={styles.fakeMarker}>
+                <Image source={marker} />
               </View>
-            ) : (
-              <View style={[styles.placeholder, styles.map]}>
-                {mapsError !== 3 && !latitude && (
-                  <ActivityIndicator
-                    style={styles.spinner}
-                    size={80}
-                    color={colors.palered}
-                  />
-                )}
-                {!mapsError && !latitude ? (
-                  <Text style={globalStyles.h2}>
-                    {t('views.family.gettingYourLocation')}
+              <SearchBar
+                id="searchAddress"
+                style={styles.search}
+                placeholder={t('views.family.searchByStreetOrPostalCode')}
+                onChangeText={searchAddress => this.setState({ searchAddress })}
+                onSubmit={this.searcForAddress}
+                value={searchAddress}
+              />
+              <MapView
+                ref={ref => {
+                  this.map = ref
+                }}
+                style={styles.map}
+                initialRegion={{
+                  latitude,
+                  longitude,
+                  latitudeDelta,
+                  longitudeDelta
+                }}
+                region={{
+                  latitude,
+                  longitude,
+                  latitudeDelta,
+                  longitudeDelta
+                }}
+                onRegionChangeComplete={this.onDragMap}
+              />
+              {centeringMap ? (
+                <ActivityIndicator
+                  style={styles.center}
+                  size={54}
+                  color={colors.palegreen}
+                />
+              ) : (
+                <TouchableOpacity
+                  id="centerMap"
+                  style={styles.center}
+                  onPress={this.getDeviceLocation}
+                >
+                  <Image source={center} style={{ width: 21, height: 21 }} />
+                </TouchableOpacity>
+              )}
+            </View>
+          ) : (
+            <View style={[styles.placeholder, styles.map]}>
+              {mapsError !== 3 && !latitude && (
+                <ActivityIndicator
+                  style={styles.spinner}
+                  size={80}
+                  color={colors.palered}
+                />
+              )}
+              {!mapsError && !latitude ? (
+                <Text style={globalStyles.h2}>
+                  {t('views.family.gettingYourLocation')}
+                </Text>
+              ) : (
+                <View>
+                  <Text style={[globalStyles.h2, styles.centerText]}>
+                    Hmmm!
                   </Text>
-                ) : (
-                  <View>
-                    <Text style={[globalStyles.h2, styles.centerText]}>
-                      Hmmm!
-                    </Text>
-                    <Text style={[styles.errorMsg, styles.centerText]}>
-                      {mapsError === 2 &&
-                        t('views.family.somethingIsNotWorking')}
+                  <Text style={[styles.errorMsg, styles.centerText]}>
+                    {mapsError === 2 && t('views.family.somethingIsNotWorking')}
 
-                      {!isOnline &&
-                        latitude &&
-                        t('views.family.mapUnavailavleOffline')}
+                    {!isOnline &&
+                      latitude &&
+                      t('views.family.mapUnavailavleOffline')}
 
-                      {!isOnline &&
-                        mapsError === 3 &&
-                        !latitude &&
-                        t('views.family.neitherMapNorLocation')}
-                    </Text>
-                    <Text style={[styles.errorSubMsg, styles.centerText]}>
-                      {mapsError === 2 &&
-                        t('views.family.checkLocationServicesTurnedOn')}
+                    {!isOnline &&
+                      mapsError === 3 &&
+                      !latitude &&
+                      t('views.family.neitherMapNorLocation')}
+                  </Text>
+                  <Text style={[styles.errorSubMsg, styles.centerText]}>
+                    {mapsError === 2 &&
+                      t('views.family.checkLocationServicesTurnedOn')}
 
-                      {!isOnline &&
-                        latitude &&
-                        t('views.family.weHaveLocation')}
+                    {!isOnline && latitude && t('views.family.weHaveLocation')}
 
-                      {!isOnline &&
-                        mapsError === 3 &&
-                        !latitude &&
-                        t('views.family.describeLocation')}
-                    </Text>
-                  </View>
-                )}
-              </View>
-            )}
-          </View>
-
-          <View>
-            <Text id="accuracy" style={styles.container}>
-              {accuracy
-                ? `${t('views.family.gpsAccurate').replace(
-                    '%n',
-                    Math.round(accuracy)
-                  )}`
-                : ' '}
-            </Text>
-            <Select
-              id="countrySelect"
-              required
-              showErrors={showErrors}
-              onChange={this.addSurveyData}
-              label={t('views.family.country')}
-              countrySelect
-              placeholder={t('views.family.selectACountry')}
-              field="country"
-              value={this.getFieldValue(draft, 'country') || ''}
-              detectError={this.detectError}
-              country={this.survey.surveyConfig.surveyLocation.country}
-            />
-            <TextInput
-              id="postCode"
-              onChangeText={this.addSurveyData}
-              field="postCode"
-              value={this.getFieldValue(draft, 'postCode') || ''}
-              placeholder={t('views.family.postcode')}
-              detectError={this.detectError}
-            />
-            <TextInput
-              id="address"
-              onChangeText={this.addSurveyData}
-              field="address"
-              value={this.getFieldValue(draft, 'address') || ''}
-              placeholder={t('views.family.streetOrHouseDescription')}
-              validation="long-string"
-              detectError={this.detectError}
-              multiline
-            />
-          </View>
+                    {!isOnline &&
+                      mapsError === 3 &&
+                      !latitude &&
+                      t('views.family.describeLocation')}
+                  </Text>
+                </View>
+              )}
+            </View>
+          )}
         </View>
-        <View style={{ marginTop: 15 }}>
-          <Button
-            id="continue"
-            colored
-            text={t('general.continue')}
-            handleClick={this.handleClick}
+
+        <View>
+          <Text id="accuracy" style={styles.container}>
+            {accuracy
+              ? `${t('views.family.gpsAccurate').replace(
+                  '%n',
+                  Math.round(accuracy)
+                )}`
+              : ' '}
+          </Text>
+          <Select
+            id="countrySelect"
+            required
+            showErrors={showErrors}
+            onChange={this.addSurveyData}
+            label={t('views.family.country')}
+            countrySelect
+            placeholder={t('views.family.selectACountry')}
+            field="country"
+            value={this.getFieldValue(draft, 'country') || ''}
+            detectError={this.detectError}
+            country={this.survey.surveyConfig.surveyLocation.country}
+          />
+          <TextInput
+            id="postCode"
+            onChangeText={this.addSurveyData}
+            field="postCode"
+            value={this.getFieldValue(draft, 'postCode') || ''}
+            placeholder={t('views.family.postcode')}
+            detectError={this.detectError}
+          />
+          <TextInput
+            id="address"
+            onChangeText={this.addSurveyData}
+            field="address"
+            value={this.getFieldValue(draft, 'address') || ''}
+            placeholder={t('views.family.streetOrHouseDescription')}
+            validation="long-string"
+            detectError={this.detectError}
+            multiline
           />
         </View>
-      </ScrollView>
+      </StickyFooter>
     )
   }
 }
@@ -454,11 +437,6 @@ const styles = StyleSheet.create({
   map: {
     height: 300,
     width: '100%'
-  },
-  contentContainer: {
-    flexGrow: 1,
-    flexDirection: 'column',
-    justifyContent: 'space-between'
   },
   placeholder: {
     alignItems: 'center',

--- a/src/screens/lifemap/Overview.js
+++ b/src/screens/lifemap/Overview.js
@@ -76,19 +76,10 @@ export class Overview extends Component {
     const draft = this.props.drafts.find(item => item.draftId === this.draftId)
     const mandatoryPrioritiesCount = this.getMandatoryPrioritiesCount(draft)
     const resumeDraft = this.props.navigation.getParam('resumeDraft')
-    console.log(draft)
     return (
-      <ScrollView
-        style={globalStyles.background}
-        contentContainerStyle={styles.contentContainer}
-      >
-        <View>
-          <View
-            style={{
-              ...globalStyles.container,
-              paddingTop: 20
-            }}
-          >
+      <View style={[globalStyles.background, styles.contentContainer]}>
+        <ScrollView>
+          <View>
             <LifemapVisual
               questions={draft.indicatorSurveyDataList}
               priorities={draft.priorities}
@@ -123,7 +114,23 @@ export class Overview extends Component {
               navigateToScreen={this.navigateToScreen}
             />
           </View>
-        </View>
+
+          {mandatoryPrioritiesCount ? (
+            <Tip
+              title={t('views.lifemap.beforeTheLifeMapIsCompleted')}
+              description={
+                mandatoryPrioritiesCount === 1
+                  ? t('views.lifemap.youNeedToAddPriotity')
+                  : t('views.lifemap.youNeedToAddPriorities').replace(
+                      '%n',
+                      mandatoryPrioritiesCount
+                    )
+              }
+            />
+          ) : (
+            <View />
+          )}
+        </ScrollView>
         {!resumeDraft ? (
           <View style={{ height: 50 }}>
             <Button
@@ -136,31 +143,17 @@ export class Overview extends Component {
             />
           </View>
         ) : null}
-
-        {mandatoryPrioritiesCount ? (
-          <Tip
-            title={t('views.lifemap.beforeTheLifeMapIsCompleted')}
-            description={
-              mandatoryPrioritiesCount === 1
-                ? t('views.lifemap.youNeedToAddPriotity')
-                : t('views.lifemap.youNeedToAddPriorities').replace(
-                    '%n',
-                    mandatoryPrioritiesCount
-                  )
-            }
-          />
-        ) : (
-          <View />
-        )}
-      </ScrollView>
+      </View>
     )
   }
 }
 const styles = StyleSheet.create({
   contentContainer: {
-    flexGrow: 1,
+    paddingTop: 20,
+    flex: 1,
     flexDirection: 'column',
-    justifyContent: 'space-between'
+    justifyContent: 'center',
+    alignItems: 'stretch'
   },
   listTitle: {
     backgroundColor: colors.beige,

--- a/src/screens/lifemap/Overview.js
+++ b/src/screens/lifemap/Overview.js
@@ -79,7 +79,7 @@ export class Overview extends Component {
     return (
       <View style={[globalStyles.background, styles.contentContainer]}>
         <ScrollView>
-          <View>
+          <View style={styles.indicatorsContainer}>
             <LifemapVisual
               questions={draft.indicatorSurveyDataList}
               priorities={draft.priorities}
@@ -161,6 +161,10 @@ const styles = StyleSheet.create({
     lineHeight: 45,
     flex: 1,
     textAlign: 'center'
+  },
+  indicatorsContainer: {
+    paddingHorizontal: 20,
+    paddingBottom: 25
   }
 })
 

--- a/src/screens/lifemap/Skipped.js
+++ b/src/screens/lifemap/Skipped.js
@@ -1,15 +1,12 @@
 import React, { Component } from 'react'
-import { StyleSheet, ScrollView, Image, View, FlatList } from 'react-native'
+import { StyleSheet, Image, FlatList } from 'react-native'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { withNamespaces } from 'react-i18next'
 import { addDraftProgress } from '../../redux/actions'
-
+import StickyFooter from '../../components/StickyFooter'
 import Tip from '../../components/Tip'
 import SkippedListItem from '../../components/SkippedListItem'
-import Button from '../../components/Button'
-
-import globalStyles from '../../globalStyles'
 
 export class Skipped extends Component {
   draftId = this.props.navigation.getParam('draftId')
@@ -53,9 +50,9 @@ export class Skipped extends Component {
       question => question.value === 0
     )
     return (
-      <ScrollView
-        style={globalStyles.background}
-        contentContainerStyle={styles.contentContainer}
+      <StickyFooter
+        handleClick={this.handleClick}
+        continueLabel={t('general.continue')}
       >
         <Image
           style={styles.image}
@@ -84,28 +81,16 @@ export class Skipped extends Component {
             />
           )}
         />
-        <View style={{ height: 50, marginTop: 20 }}>
-          <Button
-            colored
-            text={t('general.continue')}
-            handleClick={() => this.handleClick()}
-          />
-        </View>
         <Tip
           title={t('views.lifemap.youSkipped')}
           description={t('views.lifemap.whyNotTryAgain')}
         />
-      </ScrollView>
+      </StickyFooter>
     )
   }
 }
 const styles = StyleSheet.create({
-  image: { alignSelf: 'center', marginVertical: 50 },
-  contentContainer: {
-    flexGrow: 1,
-    flexDirection: 'column',
-    justifyContent: 'space-between'
-  }
+  image: { alignSelf: 'center', marginVertical: 50 }
 })
 
 Skipped.propTypes = {

--- a/src/screens/lifemap/SocioEconomicQuestion.js
+++ b/src/screens/lifemap/SocioEconomicQuestion.js
@@ -1,13 +1,11 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { ScrollView, View, StyleSheet, Text } from 'react-native'
+import { View, StyleSheet, Text } from 'react-native'
 import { connect } from 'react-redux'
 import { withNamespaces } from 'react-i18next'
-
+import StickyFooter from '../../components/StickyFooter'
 import TextInput from '../../components/TextInput'
 import Select from '../../components/Select'
-import Button from '../../components/Button'
-import globalStyles from '../../globalStyles'
 import {
   addSurveyData,
   addSurveyFamilyMemberData,
@@ -219,132 +217,117 @@ export class SocioEconomicQuestion extends Component {
       : []
 
     return (
-      <ScrollView
-        style={globalStyles.background}
-        contentContainerStyle={styles.contentContainer}
+      <StickyFooter
+        handleClick={this.submitForm}
+        continueLabel={t('general.continue')}
       >
-        <View
-          style={{
-            ...globalStyles.container,
-            padding: 0
-          }}
-        >
-          {/* questions for entire family */}
-          {socioEconomics ? (
-            questionsForThisScreen.forFamily.map(question =>
-              question.answerType === 'select' ? (
-                <Select
-                  key={question.codeName}
-                  required={question.required}
-                  onChange={this.addSurveyData}
-                  placeholder={question.questionText}
-                  showErrors={showErrors}
-                  label={question.questionText}
-                  field={question.codeName}
-                  value={this.getFieldValue(draft, question.codeName) || ''}
-                  detectError={this.detectError}
-                  options={question.options}
-                />
-              ) : question.answerType === 'number' ? (
-                <TextInput
-                  multiline
-                  key={question.codeName}
-                  required={question.required}
-                  onChangeText={this.addSurveyData}
-                  placeholder={question.questionText}
-                  showErrors={showErrors}
-                  field={question.codeName}
-                  value={this.getFieldValue(draft, question.codeName) || ''}
-                  detectError={this.detectError}
-                  validation="number"
-                  keyboardType="numeric"
-                />
-              ) : (
-                <TextInput
-                  multiline
-                  key={question.codeName}
-                  required={question.required}
-                  onChangeText={this.addSurveyData}
-                  placeholder={question.questionText}
-                  showErrors={showErrors}
-                  field={question.codeName}
-                  value={this.getFieldValue(draft, question.codeName) || ''}
-                  detectError={this.detectError}
-                />
-              )
-            )
-          ) : (
-            <View />
-          )}
-
-          {/* questions for family members */}
-          {socioEconomics ? (
-            questionsForThisScreen.forFamilyMember.length ? (
-              draft.familyData.familyMembersList.map((member, i) => (
-                <View key={member.firstName}>
-                  <Text style={styles.memberName}>{member.firstName}</Text>
-                  {questionsForThisScreen.forFamilyMember.map(question =>
-                    question.answerType === 'select' ? (
-                      <Select
-                        key={question.codeName}
-                        required={question.required}
-                        onChange={(text, field) =>
-                          this.addSurveyFamilyMemberData(text, field, i)
-                        }
-                        placeholder={question.questionText}
-                        showErrors={showErrors}
-                        label={question.questionText}
-                        field={question.codeName}
-                        value={
-                          this.getFamilyMemberFieldValue(
-                            draft,
-                            question.codeName,
-                            i
-                          ) || ''
-                        }
-                        detectError={this.detectError}
-                        options={question.options}
-                      />
-                    ) : (
-                      <TextInput
-                        key={question.codeName}
-                        multiline
-                        required={question.required}
-                        onChangeText={(text, field) =>
-                          this.addSurveyFamilyMemberData(text, field, i)
-                        }
-                        placeholder={question.questionText}
-                        showErrors={showErrors}
-                        field={question.codeName}
-                        value={
-                          this.getFamilyMemberFieldValue(
-                            draft,
-                            question.codeName,
-                            i
-                          ) || ''
-                        }
-                        detectError={this.detectError}
-                      />
-                    )
-                  )}
-                </View>
-              ))
+        {/* questions for entire family */}
+        {socioEconomics ? (
+          questionsForThisScreen.forFamily.map(question =>
+            question.answerType === 'select' ? (
+              <Select
+                key={question.codeName}
+                required={question.required}
+                onChange={this.addSurveyData}
+                placeholder={question.questionText}
+                showErrors={showErrors}
+                label={question.questionText}
+                field={question.codeName}
+                value={this.getFieldValue(draft, question.codeName) || ''}
+                detectError={this.detectError}
+                options={question.options}
+              />
+            ) : question.answerType === 'number' ? (
+              <TextInput
+                multiline
+                key={question.codeName}
+                required={question.required}
+                onChangeText={this.addSurveyData}
+                placeholder={question.questionText}
+                showErrors={showErrors}
+                field={question.codeName}
+                value={this.getFieldValue(draft, question.codeName) || ''}
+                detectError={this.detectError}
+                validation="number"
+                keyboardType="numeric"
+              />
             ) : (
-              <View />
+              <TextInput
+                multiline
+                key={question.codeName}
+                required={question.required}
+                onChangeText={this.addSurveyData}
+                placeholder={question.questionText}
+                showErrors={showErrors}
+                field={question.codeName}
+                value={this.getFieldValue(draft, question.codeName) || ''}
+                detectError={this.detectError}
+              />
             )
+          )
+        ) : (
+          <View />
+        )}
+
+        {/* questions for family members */}
+        {socioEconomics ? (
+          questionsForThisScreen.forFamilyMember.length ? (
+            draft.familyData.familyMembersList.map((member, i) => (
+              <View key={member.firstName}>
+                <Text style={styles.memberName}>{member.firstName}</Text>
+                {questionsForThisScreen.forFamilyMember.map(question =>
+                  question.answerType === 'select' ? (
+                    <Select
+                      key={question.codeName}
+                      required={question.required}
+                      onChange={(text, field) =>
+                        this.addSurveyFamilyMemberData(text, field, i)
+                      }
+                      placeholder={question.questionText}
+                      showErrors={showErrors}
+                      label={question.questionText}
+                      field={question.codeName}
+                      value={
+                        this.getFamilyMemberFieldValue(
+                          draft,
+                          question.codeName,
+                          i
+                        ) || ''
+                      }
+                      detectError={this.detectError}
+                      options={question.options}
+                    />
+                  ) : (
+                    <TextInput
+                      key={question.codeName}
+                      multiline
+                      required={question.required}
+                      onChangeText={(text, field) =>
+                        this.addSurveyFamilyMemberData(text, field, i)
+                      }
+                      placeholder={question.questionText}
+                      showErrors={showErrors}
+                      field={question.codeName}
+                      value={
+                        this.getFamilyMemberFieldValue(
+                          draft,
+                          question.codeName,
+                          i
+                        ) || ''
+                      }
+                      detectError={this.detectError}
+                    />
+                  )
+                )}
+              </View>
+            ))
           ) : (
             <View />
-          )}
-        </View>
-        <View style={{ marginTop: 15, height: 50 }}>
-          <Button
-            id="continue"
-            colored
-            text={t('general.continue')}
-            handleClick={this.submitForm}
-          />
-        </View>
-      </ScrollView>
+          )
+        ) : (
+          <View />
+        )}
+      </StickyFooter>
     )
   }
 }
@@ -359,11 +342,6 @@ SocioEconomicQuestion.propTypes = {
 }
 
 const styles = StyleSheet.create({
-  contentContainer: {
-    flexGrow: 1,
-    flexDirection: 'column',
-    justifyContent: 'space-between'
-  },
   memberName: {
     marginHorizontal: 20,
     fontWeight: 'normal',


### PR DESCRIPTION
In this pull request we make the continu/save button stick to the bottom of the screen even when the content is long.

**To Test**
Testing on a small device/emulator makes it easier to see the sticky button as less content is needed to fill in the page. Also you can continue a draft, but since you need to cover the whole process starting a new one is easier.
1. Go to Primary Participant. 
2. Now the Continue button should stick to the bottom of the device screen and be visible at all times. You can scroll the rest of the content as you wish. When you scroll to the bottom, everything should be visible and the Continue button should not be on top of anything.
3. Tap on Continue without filling all the required fields. The errors should appear and you should not continue to the next view.
4. Fill in the fields and tap the button. Now you should navigate to the next screen.
5. Repeat steps 2 to 4 for Family member names, genders and birthdates, family location, socio economic screens (Sierra Leone survey has one page which is long), Add Priority/Achievement, Skipped screen (skip 8-10 questions to see the effect) and Overview.
