### PR TITLE
Fix placeholder for country of birth in family participant

### DIFF
--- a/src/screens/lifemap/FamilyParticipant.js
+++ b/src/screens/lifemap/FamilyParticipant.js
@@ -199,7 +199,7 @@ export class FamilyParticipant extends Component {
           label={t('views.family.countryOfBirth')}
           countrySelect
           country={this.survey.surveyConfig.surveyLocation.country}
-          placeholder={t('views.family.selectACountry')}
+          placeholder={t('views.family.countryOfBirth')}
           field="birthCountry"
           value={
             this.getFieldValue(draft, 'birthCountry') ||


### PR DESCRIPTION
**Describe the changes**
On the family participant screen the country select now says 'Country of birth"

