### PR TITLE
Indicator filters

### DIFF
--- a/src/components/BottomModal.js
+++ b/src/components/BottomModal.js
@@ -47,7 +47,7 @@ BottomModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onRequestClose: PropTypes.func.isRequired,
   onEmptyClose: PropTypes.func.isRequired,
-  children: PropTypes.array
+  children: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
 }
 
 const styles = StyleSheet.create({

--- a/src/components/BottomModal.js
+++ b/src/components/BottomModal.js
@@ -1,0 +1,64 @@
+// This is a modal + overlay that pops up from the bottom of the screen.
+// This components is used in the indicators filters and select dropdowns.
+
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { View, Modal, StyleSheet, TouchableOpacity } from 'react-native'
+
+export default class BottomModal extends Component {
+  render() {
+    const { isOpen, onRequestClose, children, onEmptyClose } = this.props
+    return (
+      <View>
+        <Modal
+          transparent={true}
+          visible={isOpen}
+          onRequestClose={onRequestClose}
+        >
+          <TouchableOpacity
+            style={[
+              styles.overlay,
+              {
+                backgroundColor: 'rgba(47,38,28, 0.2)'
+              }
+            ]}
+          />
+        </Modal>
+        <Modal
+          id="content"
+          animationType="slide"
+          transparent={true}
+          visible={isOpen}
+          onRequestClose={onRequestClose}
+        >
+          <TouchableOpacity
+            id="overlay"
+            style={styles.overlay}
+            onPress={onEmptyClose}
+          />
+          {children}
+        </Modal>
+      </View>
+    )
+  }
+}
+
+BottomModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onRequestClose: PropTypes.func.isRequired,
+  onEmptyClose: PropTypes.func.isRequired,
+  children: PropTypes.array
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: -200,
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center'
+  }
+})

--- a/src/components/LifemapOverview.js
+++ b/src/components/LifemapOverview.js
@@ -8,9 +8,9 @@ import globalStyles from '../globalStyles'
 class LifemapOverview extends Component {
   dimensions = this.props.surveyData.map(item => item.dimension)
 
-  getColor = color => {
+  getColor = codeName => {
     const indicator = this.props.draftData.indicatorSurveyDataList.find(
-      item => item.key === color
+      item => item.key === codeName
     )
     if (indicator) {
       return indicator.value
@@ -35,11 +35,31 @@ class LifemapOverview extends Component {
     }
   }
   filterByDimension = item =>
-    this.props.surveyData.filter(
-      indicator =>
-        indicator.dimension === item &&
-        typeof this.getColor(indicator.codeName) === 'number'
-    )
+    this.props.surveyData.filter(indicator => {
+      const colorCode = this.getColor(indicator.codeName)
+      if (this.props.selectedFilter === false) {
+        return indicator.dimension === item && typeof colorCode === 'number'
+      } else if (this.props.selectedFilter === 'priorities') {
+        const priorities = this.props.draftData.priorities.map(
+          priority => priority.indicator
+        )
+        const achievements = this.props.draftData.achievements.map(
+          priority => priority.indicator
+        )
+
+        return (
+          indicator.dimension === item &&
+          (priorities.includes(indicator.codeName) ||
+            achievements.includes(indicator.codeName))
+        )
+      } else {
+        return (
+          indicator.dimension === item &&
+          typeof colorCode === 'number' &&
+          colorCode === this.props.selectedFilter
+        )
+      }
+    })
   render() {
     const priorities = this.props.draftData.priorities.map(
       priority => priority.indicator
@@ -47,6 +67,7 @@ class LifemapOverview extends Component {
     const achievements = this.props.draftData.achievements.map(
       priority => priority.indicator
     )
+
     return (
       <View style={styles.container}>
         {[...new Set(this.dimensions)].map(item => (
@@ -54,22 +75,24 @@ class LifemapOverview extends Component {
             {this.filterByDimension(item).length ? (
               <Text style={styles.dimension}>{item.toUpperCase()}</Text>
             ) : null}
-            {this.filterByDimension(item).map(indicator => (
-              <LifemapOverviewListItem
-                key={indicator.questionText}
-                name={indicator.questionText}
-                color={this.getColor(indicator.codeName)}
-                priority={priorities.includes(indicator.codeName)}
-                achievement={achievements.includes(indicator.codeName)}
-                handleClick={() =>
-                  this.handleClick(
-                    this.getColor(indicator.codeName),
-                    indicator.codeName,
-                    indicator.questionText
-                  )
-                }
-              />
-            ))}
+            {this.filterByDimension(item).map(indicator => {
+              return (
+                <LifemapOverviewListItem
+                  key={indicator.questionText}
+                  name={indicator.questionText}
+                  color={this.getColor(indicator.codeName)}
+                  priority={priorities.includes(indicator.codeName)}
+                  achievement={achievements.includes(indicator.codeName)}
+                  handleClick={() =>
+                    this.handleClick(
+                      this.getColor(indicator.codeName),
+                      indicator.codeName,
+                      indicator.questionText
+                    )
+                  }
+                />
+              )
+            })}
           </View>
         ))}
       </View>
@@ -80,7 +103,12 @@ class LifemapOverview extends Component {
 LifemapOverview.propTypes = {
   surveyData: PropTypes.array.isRequired,
   draftData: PropTypes.object.isRequired,
-  navigateToScreen: PropTypes.func.isRequired
+  navigateToScreen: PropTypes.func.isRequired,
+  selectedFilter: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number,
+    PropTypes.string
+  ])
 }
 
 const styles = StyleSheet.create({

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -5,10 +5,10 @@ import {
   StyleSheet,
   View,
   Text,
-  Modal,
   Image,
   ScrollView
 } from 'react-native'
+import BottomModal from './BottomModal'
 import countries from 'localized-countries'
 import arrow from '../../assets/images/selectArrow.png'
 import colors from '../theme.json'
@@ -134,34 +134,14 @@ class Select extends Component {
             </Text>
             <Image source={arrow} style={styles.arrow} />
 
-            <Modal
-              transparent={true}
-              visible={isOpen}
+            <BottomModal
+              isOpen={isOpen}
               onRequestClose={this.toggleDropdown}
+              onEmptyClose={() => {
+                this.validateInput('')
+                this.toggleDropdown()
+              }}
             >
-              <TouchableOpacity
-                style={[
-                  styles.overlay,
-                  {
-                    backgroundColor: 'rgba(47,38,28, 0.2)'
-                  }
-                ]}
-                onPress={this.toggleDropdown}
-              />
-            </Modal>
-            <Modal
-              animationType="slide"
-              transparent={true}
-              visible={isOpen}
-              onRequestClose={this.toggleDropdown}
-            >
-              <TouchableOpacity
-                style={styles.overlay}
-                onPress={() => {
-                  this.validateInput('')
-                  this.toggleDropdown()
-                }}
-              />
               <View style={styles.dropdown}>
                 {countrySelect ? (
                   <ScrollView>
@@ -201,7 +181,7 @@ class Select extends Component {
                   </ScrollView>
                 )}
               </View>
-            </Modal>
+            </BottomModal>
           </View>
           {/* Error message */}
           {!!errorMsg && (
@@ -279,16 +259,6 @@ const styles = StyleSheet.create({
   error: {
     backgroundColor: colors.white,
     borderBottomColor: colors.red
-  },
-  overlay: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: -200,
-    flexDirection: 'column',
-    justifyContent: 'center',
-    alignItems: 'center'
   },
   selected: {
     backgroundColor: colors.lightgrey

--- a/src/components/__tests__/BottomModal.test.js
+++ b/src/components/__tests__/BottomModal.test.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import BottomModal from '../BottomModal'
+
+const createTestProps = props => ({
+  isOpen: true,
+  onRequestClose: jest.fn(),
+  onEmptyClose: jest.fn(),
+  children: [],
+  ...props
+})
+
+describe('BottomModal Component', () => {
+  let wrapper
+  let props
+  beforeEach(() => {
+    props = createTestProps()
+    wrapper = shallow(<BottomModal {...props} />)
+  })
+
+  it('calls onRequestClose when modal is closed', () => {
+    wrapper
+      .find('#content')
+      .props()
+      .onRequestClose()
+
+    expect(props.onRequestClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onEmptyClose when overlay is tapped', () => {
+    wrapper
+      .find('#overlay')
+      .props()
+      .onPress()
+
+    expect(props.onEmptyClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/__tests__/LifemapOverview.test.js
+++ b/src/components/__tests__/LifemapOverview.test.js
@@ -34,6 +34,7 @@ const createTestProps = props => ({
       }
     ]
   },
+  selectedFilter: false,
   navigateToScreen: jest.fn(),
   ...props
 })

--- a/src/components/__tests__/LifemapOverview.test.js
+++ b/src/components/__tests__/LifemapOverview.test.js
@@ -17,11 +17,21 @@ const createTestProps = props => ({
       codeName: 'FamilyIncome',
       questionText: 'Family Income',
       dimension: 'Income'
+    },
+    {
+      codeName: 'FamilyHealth',
+      questionText: 'Family Health',
+      dimension: 'Health & Environment'
+    },
+    {
+      codeName: 'Money',
+      questionText: 'Family Money',
+      dimension: 'Income'
     }
   ],
   draftData: {
     draftId: 1,
-    priorities: [{ action: 'Some action' }],
+    priorities: [{ action: 'Some action', indicator: 'FamilyHealth' }],
     achievements: [{ action: 'Some action' }],
     indicatorSurveyDataList: [
       {
@@ -31,6 +41,10 @@ const createTestProps = props => ({
       {
         key: 'FamilyIncome',
         value: 3
+      },
+      {
+        key: 'FamilyHealth',
+        value: 2
       }
     ]
   },
@@ -55,7 +69,7 @@ describe('LifemapOverview Component', () => {
       expect(wrapper.find(Text)).toHaveLength(2)
     })
     it('renders LifemapOverviewListItem', () => {
-      expect(wrapper.find(LifemapOverviewListItem)).toHaveLength(2)
+      expect(wrapper.find(LifemapOverviewListItem)).toHaveLength(3)
     })
   })
   describe('functionality', () => {
@@ -171,6 +185,46 @@ describe('LifemapOverview Component', () => {
         'FamilyIncome',
         'Family Income'
       )
+    })
+    it('filters color items by dimension', () => {
+      props = createTestProps({
+        selectedFilter: 2
+      })
+      wrapper = shallow(<LifemapOverview {...props} />)
+      expect(
+        wrapper.instance().filterByDimension('Health & Environment')
+      ).toHaveLength(2)
+    })
+    it('filters skipped items by dimension', () => {
+      props = createTestProps({
+        selectedFilter: 0,
+        draftData: {
+          draftId: 1,
+          priorities: [],
+          achievements: [],
+          indicatorSurveyDataList: [
+            {
+              key: 'FamilySavings',
+              value: 2
+            },
+            {
+              key: 'Money',
+              value: 0
+            }
+          ]
+        }
+      })
+      wrapper = shallow(<LifemapOverview {...props} />)
+      expect(wrapper.instance().filterByDimension('Income')).toHaveLength(1)
+    })
+    it('filters items with achievements/priorities by dimension', () => {
+      props = createTestProps({
+        selectedFilter: 'priorities'
+      })
+      wrapper = shallow(<LifemapOverview {...props} />)
+      expect(
+        wrapper.instance().filterByDimension('Health & Environment')
+      ).toHaveLength(1)
     })
   })
 })

--- a/src/components/__tests__/Select.test.js
+++ b/src/components/__tests__/Select.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import { TouchableOpacity, Text, Modal } from 'react-native'
 import Select from '../Select'
+import BottomModal from '../BottomModal'
 
 const createTestProps = props => ({
   onChange: jest.fn(),
@@ -40,51 +41,31 @@ describe('Select dropdown', () => {
       .onPress()
 
     expect(wrapper).toHaveState({ isOpen: true })
-    expect(
-      wrapper
-        .find(Modal)
-        .last()
-        .find(TouchableOpacity)
-    ).toHaveLength(5)
+    expect(wrapper.find(BottomModal)).toHaveProp({ isOpen: true })
   })
 
   it('selects an option when one is pressed', () => {
     const spy = jest.spyOn(wrapper.instance(), 'validateInput')
-    wrapper
-      .find(TouchableOpacity)
-      .first()
-      .props()
-      .onPress()
 
     wrapper
-      .find(Modal)
-      .last()
+      .find(BottomModal)
       .find(TouchableOpacity)
-      .at(3)
+      .at(1)
       .props()
       .onPress()
 
     expect(spy).toHaveBeenCalledTimes(1)
-    expect(spy).toHaveBeenCalledWith('us')
+    expect(spy).toHaveBeenCalledWith('bg')
   })
   it('selects NONE if the last option is pressed', () => {
     const spy = jest.spyOn(wrapper.instance(), 'validateInput')
     wrapper
-      .find(TouchableOpacity)
-      .first()
+      .find(BottomModal)
       .props()
-      .onPress()
-
-    wrapper
-      .find(Modal)
-      .last()
-      .find(TouchableOpacity)
-      .last()
-      .props()
-      .onPress()
+      .onEmptyClose()
 
     expect(spy).toHaveBeenCalledTimes(1)
-    expect(spy).toHaveBeenCalledWith('NONE')
+    expect(spy).toHaveBeenCalledWith('')
   })
   it('render a list of items when passed options', () => {
     props = createTestProps({
@@ -103,13 +84,13 @@ describe('Select dropdown', () => {
 
     expect(
       wrapper
-        .find(Modal)
+        .find(BottomModal)
         .last()
         .find(TouchableOpacity)
-    ).toHaveLength(3)
+    ).toHaveLength(2)
 
     wrapper
-      .find(Modal)
+      .find(BottomModal)
       .last()
       .find(TouchableOpacity)
       .last()

--- a/src/components/__tests__/Select.test.js
+++ b/src/components/__tests__/Select.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { TouchableOpacity, Text, Modal } from 'react-native'
+import { TouchableOpacity, Text } from 'react-native'
 import Select from '../Select'
 import BottomModal from '../BottomModal'
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -20,7 +20,8 @@
     "resumeDraft": "Resume draft",
     "lifeMaps": "Life Maps",
     "familyInfo": "family info",
-    "cachedData": "cached data"
+    "cachedData": "cached data",
+    "chooseView": "Choose view"
   },
   "validation": {
     "fieldIsRequired": "This field is required",
@@ -119,7 +120,12 @@
       "youHaveCompletedTheLifemap": "You have completed the lifemap",
       "youNeedToAddPriotity": "You need to add one priority",
       "youNeedToAddPriorities": "You need to add %n priorities",
-      "beforeTheLifeMapIsCompleted": "Before the life map is completed..."
+      "beforeTheLifeMapIsCompleted": "Before the life map is completed...",
+      "green": "Green",
+      "yellow": "Yellow",
+      "red": "Red",
+      "priorities": "Priorities",
+      "achievements": "Achievements"
     },
     "modals": {
       "lifeMapWillNotBeSaved": "If you do not enter all details on this page the life map will not be saved!",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -20,7 +20,8 @@
     "resumeDraft": "Continuar borrador",
     "lifeMaps": "Mapas de Vida",
     "familyInfo": "Información de la familia",
-    "cachedData": "Datos almacenados"
+    "cachedData": "Datos almacenados",
+    "chooseView": "Elegir vista"
   },
   "validation": {
     "fieldIsRequired": "Este campo es requerido",
@@ -119,7 +120,12 @@
       "youHaveCompletedTheLifemap": "Has completado tu Mapa de Vida",
       "youNeedToAddPriotity": "Necesitas agregar una prioridad",
       "youNeedToAddPriorities": "Necesitas agregar %n prioridades",
-      "beforeTheLifeMapIsCompleted": "Antes de que se complete el Mapa de Vida...."
+      "beforeTheLifeMapIsCompleted": "Antes de que se complete el Mapa de Vida....",
+      "green": "Verde",
+      "yellow": "Amarillo",
+      "red": "Rojo",
+      "priorities": "Prioridades",
+      "achievements": "Logros"
     },
     "modals": {
       "lifeMapWillNotBeSaved": "Si no ingresa todos los detalles en esta página, ¡el Mapa de Vida no se guardará!",

--- a/src/screens/__tests__/Overview.test.js
+++ b/src/screens/__tests__/Overview.test.js
@@ -6,6 +6,7 @@ import Button from '../../components/Button'
 import Tip from '../../components/Tip'
 import LifemapVisual from '../../components/LifemapVisual'
 import LifemapOverview from '../../components/LifemapOverview'
+import BottomModal from '../../components/BottomModal'
 
 const createTestProps = props => ({
   t: value => value,
@@ -42,7 +43,8 @@ const createTestProps = props => ({
         { key: 'phoneNumber', value: 3 },
         { key: 'education', value: 1 },
         { key: 'ind', value: 1 },
-        { key: 'Other ind', value: 2 }
+        { key: 'Other ind', value: 2 },
+        { key: 'Skipped', value: 0 }
       ]
     }
   ],
@@ -138,7 +140,8 @@ describe('Overview Lifemap View when no questions are skipped', () => {
           { key: 'phoneNumber', value: 3 },
           { key: 'education', value: 1 },
           { key: 'ind', value: 1 },
-          { key: 'Other ind', value: 2 }
+          { key: 'Other ind', value: 2 },
+          { key: 'Skipped', value: 0 }
         ]
       })
     })
@@ -189,5 +192,117 @@ describe('Render optimization', () => {
 
     wrapper.instance().onPressBack()
     expect(spy).toHaveBeenCalledTimes(1)
+    expect(props.navigation.navigate).toHaveBeenCalledTimes(1)
+  })
+
+  it('navigates back to skipped screen if there are skipped questions', () => {
+    wrapper.instance().onPressBack()
+
+    expect(props.navigation.navigate).toHaveBeenCalledWith('Skipped', {
+      draftId: 1,
+      survey: {
+        id: 2,
+        minimumPriorities: 5,
+        surveyStoplightQuestions: [
+          { phoneNumber: 'phoneNumber' },
+          { education: 'education' },
+          { c: 'c' }
+        ],
+        title: 'Other survey'
+      }
+    })
+  })
+
+  it('can filter by colors', () => {
+    wrapper
+      .find('#green')
+      .props()
+      .onPress()
+
+    expect(wrapper).toHaveState({ selectedFilter: 3 })
+
+    wrapper
+      .find('#yellow')
+      .props()
+      .onPress()
+
+    expect(wrapper).toHaveState({ filterLabel: 'views.lifemap.yellow' })
+
+    const spy = jest.spyOn(wrapper.instance(), 'selectFilter')
+
+    wrapper
+      .find('#red')
+      .props()
+      .onPress()
+
+    expect(spy).toHaveBeenCalledWith(1, 'views.lifemap.red')
+
+    expect(wrapper).toHaveState({
+      filterLabel: 'views.lifemap.red',
+      selectedFilter: 1
+    })
+  })
+
+  it('can filter skipped questions', () => {
+    const spy = jest.spyOn(wrapper.instance(), 'selectFilter')
+
+    wrapper
+      .find('#skipped')
+      .props()
+      .onPress()
+
+    expect(wrapper).toHaveState({ selectedFilter: 0 })
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('can filter questions by priorities/achievements', () => {
+    const spy = jest.spyOn(wrapper.instance(), 'selectFilter')
+
+    wrapper
+      .find('#priorities')
+      .props()
+      .onPress()
+
+    expect(wrapper).toHaveState({ selectedFilter: 'priorities' })
+    expect(spy).toHaveBeenCalledWith(
+      'priorities',
+      'views.lifemap.priorities & views.lifemap.achievements'
+    )
+  })
+
+  it('will revert to all indicators when selected or when closing the modal', () => {
+    const spy = jest.spyOn(wrapper.instance(), 'selectFilter')
+
+    wrapper
+      .find('#all')
+      .props()
+      .onPress()
+
+    expect(wrapper).toHaveState({ selectedFilter: false })
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    wrapper
+      .find(BottomModal)
+      .props()
+      .onEmptyClose()
+
+    expect(wrapper).toHaveState({ selectedFilter: false })
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+
+  it('will toggle modal', () => {
+    wrapper
+      .find('#filters')
+      .props()
+      .onPress()
+
+    expect(wrapper).toHaveState({ filterModalIsOpen: true })
+
+    wrapper
+      .find(BottomModal)
+      .props()
+      .onRequestClose()
+
+    expect(wrapper).toHaveState({ filterModalIsOpen: false })
   })
 })

--- a/src/screens/lifemap/Overview.js
+++ b/src/screens/lifemap/Overview.js
@@ -130,7 +130,7 @@ export class Overview extends Component {
             ) : null}
           </View>
           <View>
-            <TouchableOpacity onPress={this.toggleFilterModal}>
+            <TouchableOpacity id="filters" onPress={this.toggleFilterModal}>
               <View style={styles.listTitle}>
                 <Text style={globalStyles.subline}>
                   {filterLabel || t('views.lifemap.allIndicators')}
@@ -188,6 +188,7 @@ export class Overview extends Component {
 
             {/* All */}
             <TouchableOpacity
+              id="all"
               style={styles.row}
               onPress={() => this.selectFilter(false)}
             >
@@ -200,6 +201,7 @@ export class Overview extends Component {
 
             {/* Green */}
             <TouchableOpacity
+              id="green"
               style={styles.row}
               onPress={() => this.selectFilter(3, t('views.lifemap.green'))}
             >
@@ -218,6 +220,7 @@ export class Overview extends Component {
 
             {/* Yellow */}
             <TouchableOpacity
+              id="yellow"
               style={styles.row}
               onPress={() => this.selectFilter(2, t('views.lifemap.yellow'))}
             >
@@ -234,6 +237,7 @@ export class Overview extends Component {
 
             {/* Red */}
             <TouchableOpacity
+              id="red"
               style={styles.row}
               onPress={() => this.selectFilter(1, t('views.lifemap.red'))}
             >
@@ -250,6 +254,7 @@ export class Overview extends Component {
 
             {/* Priorities/achievements */}
             <TouchableOpacity
+              id="priorities"
               style={styles.row}
               onPress={() =>
                 this.selectFilter(
@@ -270,6 +275,7 @@ export class Overview extends Component {
 
             {/* Skipped */}
             <TouchableOpacity
+              id="skipped"
               style={styles.row}
               onPress={() => this.selectFilter(0, t('views.skippedIndicators'))}
             >

--- a/src/screens/lifemap/Overview.js
+++ b/src/screens/lifemap/Overview.js
@@ -15,19 +15,18 @@ import Tip from '../../components/Tip'
 import LifemapVisual from '../../components/LifemapVisual'
 import Button from '../../components/Button'
 import LifemapOverview from '../../components/LifemapOverview'
+import BottomModal from '../../components/BottomModal'
 import arrow from '../../../assets/images/selectArrow.png'
 import globalStyles from '../../globalStyles'
 import colors from '../../theme.json'
 
 export class Overview extends Component {
   state = {
-    filterModalIsOpen: false
+    filterModalIsOpen: false,
+    selectedFilter: false
   }
   draftId = this.props.navigation.getParam('draftId')
   survey = this.props.navigation.getParam('survey')
-  indicatorsArray = this.survey.surveyStoplightQuestions.map(
-    item => item.codeName
-  )
 
   componentDidMount() {
     if (!this.props.navigation.getParam('resumeDraft')) {
@@ -71,9 +70,15 @@ export class Overview extends Component {
   }
 
   toggleFilterModal = () => {
-    console.log('toggleFilterModal')
     this.setState({
       filterModalIsOpen: !this.state.filterModalIsOpen
+    })
+  }
+
+  selectFilter = filter => {
+    this.setState({
+      selectedFilter: filter,
+      filterModalIsOpen: false
     })
   }
 
@@ -89,9 +94,11 @@ export class Overview extends Component {
 
   render() {
     const { t } = this.props
+    const { filterModalIsOpen, selectedFilter } = this.state
     const draft = this.props.drafts.find(item => item.draftId === this.draftId)
     const mandatoryPrioritiesCount = this.getMandatoryPrioritiesCount(draft)
     const resumeDraft = this.props.navigation.getParam('resumeDraft')
+
     return (
       <View style={[globalStyles.background, styles.contentContainer]}>
         <ScrollView>
@@ -133,6 +140,7 @@ export class Overview extends Component {
               surveyData={this.survey.surveyStoplightQuestions}
               draftData={draft}
               navigateToScreen={this.navigateToScreen}
+              selectedFilter={selectedFilter}
             />
           </View>
 
@@ -164,6 +172,111 @@ export class Overview extends Component {
             />
           </View>
         ) : null}
+        {/* Filters modal */}
+        <BottomModal
+          isOpen={filterModalIsOpen}
+          onRequestClose={this.toggleFilterModal}
+          onEmptyClose={() => this.selectFilter(false)}
+        >
+          <View style={styles.dropdown}>
+            <Text style={[globalStyles.p, styles.modalTitle]}>
+              {t('general.chooseView')}
+            </Text>
+
+            {/* All */}
+            <TouchableOpacity
+              style={styles.row}
+              onPress={() => this.selectFilter(false)}
+            >
+              <View style={[styles.circle, { backgroundColor: '#EAD1AF' }]} />
+              <Text>
+                {t('views.lifemap.allIndicators')} (
+                {draft.indicatorSurveyDataList.length})
+              </Text>
+            </TouchableOpacity>
+
+            {/* Green */}
+            <TouchableOpacity
+              style={styles.row}
+              onPress={() => this.selectFilter(3)}
+            >
+              <View
+                style={[styles.circle, { backgroundColor: colors.green }]}
+              />
+              <Text>
+                {t('views.lifemap.green')} (
+                {
+                  draft.indicatorSurveyDataList.filter(item => item.value === 3)
+                    .length
+                }
+                )
+              </Text>
+            </TouchableOpacity>
+
+            {/* Yellow */}
+            <TouchableOpacity
+              style={styles.row}
+              onPress={() => this.selectFilter(2)}
+            >
+              <View style={[styles.circle, { backgroundColor: colors.gold }]} />
+              <Text>
+                {t('views.lifemap.yellow')} (
+                {
+                  draft.indicatorSurveyDataList.filter(item => item.value === 2)
+                    .length
+                }
+                )
+              </Text>
+            </TouchableOpacity>
+
+            {/* Red */}
+            <TouchableOpacity
+              style={styles.row}
+              onPress={() => this.selectFilter(1)}
+            >
+              <View style={[styles.circle, { backgroundColor: colors.red }]} />
+              <Text>
+                {t('views.lifemap.red')} (
+                {
+                  draft.indicatorSurveyDataList.filter(item => item.value === 1)
+                    .length
+                }
+                )
+              </Text>
+            </TouchableOpacity>
+
+            {/* Priorities/achievements */}
+            <TouchableOpacity
+              style={styles.row}
+              onPress={() => this.selectFilter('priorities')}
+            >
+              <View style={[styles.circle, { backgroundColor: colors.blue }]} />
+              <Text>
+                {t('views.lifemap.priorities')} &{' '}
+                {t('views.lifemap.achievements')} (
+                {draft.priorities.length + draft.achievements.length})
+              </Text>
+            </TouchableOpacity>
+
+            {/* Skipped */}
+            <TouchableOpacity
+              style={styles.row}
+              onPress={() => this.selectFilter(0)}
+            >
+              <View
+                style={[styles.circle, { backgroundColor: colors.palegrey }]}
+              />
+              <Text>
+                {t('views.skippedIndicators')} (
+                {
+                  draft.indicatorSurveyDataList.filter(item => item.value === 0)
+                    .length
+                }
+                )
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </BottomModal>
       </View>
     )
   }
@@ -192,6 +305,26 @@ const styles = StyleSheet.create({
     marginTop: 3,
     width: 10,
     height: 5
+  },
+  dropdown: {
+    padding: 16,
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: colors.palebeige
+  },
+  modalTitle: { color: colors.grey, fontWeight: '300', marginBottom: 25 },
+  circle: {
+    width: 25,
+    height: 25,
+    borderRadius: 50,
+    marginRight: 30
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 23
   }
 })
 

--- a/src/screens/lifemap/Overview.js
+++ b/src/screens/lifemap/Overview.js
@@ -23,7 +23,8 @@ import colors from '../../theme.json'
 export class Overview extends Component {
   state = {
     filterModalIsOpen: false,
-    selectedFilter: false
+    selectedFilter: false,
+    filterLabel: false
   }
   draftId = this.props.navigation.getParam('draftId')
   survey = this.props.navigation.getParam('survey')
@@ -75,10 +76,11 @@ export class Overview extends Component {
     })
   }
 
-  selectFilter = filter => {
+  selectFilter = (filter, filterLabel = false) => {
     this.setState({
       selectedFilter: filter,
-      filterModalIsOpen: false
+      filterModalIsOpen: false,
+      filterLabel: filterLabel
     })
   }
 
@@ -94,7 +96,7 @@ export class Overview extends Component {
 
   render() {
     const { t } = this.props
-    const { filterModalIsOpen, selectedFilter } = this.state
+    const { filterModalIsOpen, selectedFilter, filterLabel } = this.state
     const draft = this.props.drafts.find(item => item.draftId === this.draftId)
     const mandatoryPrioritiesCount = this.getMandatoryPrioritiesCount(draft)
     const resumeDraft = this.props.navigation.getParam('resumeDraft')
@@ -131,7 +133,7 @@ export class Overview extends Component {
             <TouchableOpacity onPress={this.toggleFilterModal}>
               <View style={styles.listTitle}>
                 <Text style={globalStyles.subline}>
-                  {t('views.lifemap.allIndicators')}
+                  {filterLabel || t('views.lifemap.allIndicators')}
                 </Text>
                 <Image source={arrow} style={styles.arrow} />
               </View>
@@ -172,6 +174,7 @@ export class Overview extends Component {
             />
           </View>
         ) : null}
+
         {/* Filters modal */}
         <BottomModal
           isOpen={filterModalIsOpen}
@@ -198,7 +201,7 @@ export class Overview extends Component {
             {/* Green */}
             <TouchableOpacity
               style={styles.row}
-              onPress={() => this.selectFilter(3)}
+              onPress={() => this.selectFilter(3, t('views.lifemap.green'))}
             >
               <View
                 style={[styles.circle, { backgroundColor: colors.green }]}
@@ -216,7 +219,7 @@ export class Overview extends Component {
             {/* Yellow */}
             <TouchableOpacity
               style={styles.row}
-              onPress={() => this.selectFilter(2)}
+              onPress={() => this.selectFilter(2, t('views.lifemap.yellow'))}
             >
               <View style={[styles.circle, { backgroundColor: colors.gold }]} />
               <Text>
@@ -232,7 +235,7 @@ export class Overview extends Component {
             {/* Red */}
             <TouchableOpacity
               style={styles.row}
-              onPress={() => this.selectFilter(1)}
+              onPress={() => this.selectFilter(1, t('views.lifemap.red'))}
             >
               <View style={[styles.circle, { backgroundColor: colors.red }]} />
               <Text>
@@ -248,7 +251,14 @@ export class Overview extends Component {
             {/* Priorities/achievements */}
             <TouchableOpacity
               style={styles.row}
-              onPress={() => this.selectFilter('priorities')}
+              onPress={() =>
+                this.selectFilter(
+                  'priorities',
+                  `${t('views.lifemap.priorities')} & ${t(
+                    'views.lifemap.achievements'
+                  )}`
+                )
+              }
             >
               <View style={[styles.circle, { backgroundColor: colors.blue }]} />
               <Text>
@@ -261,7 +271,7 @@ export class Overview extends Component {
             {/* Skipped */}
             <TouchableOpacity
               style={styles.row}
-              onPress={() => this.selectFilter(0)}
+              onPress={() => this.selectFilter(0, t('views.skippedIndicators'))}
             >
               <View
                 style={[styles.circle, { backgroundColor: colors.palegrey }]}

--- a/src/screens/lifemap/Overview.js
+++ b/src/screens/lifemap/Overview.js
@@ -1,19 +1,28 @@
 import React, { Component } from 'react'
-import { StyleSheet, ScrollView, View, Text } from 'react-native'
+import {
+  StyleSheet,
+  ScrollView,
+  View,
+  Text,
+  Image,
+  TouchableOpacity
+} from 'react-native'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { withNamespaces } from 'react-i18next'
 import { addDraftProgress } from '../../redux/actions'
-
 import Tip from '../../components/Tip'
 import LifemapVisual from '../../components/LifemapVisual'
 import Button from '../../components/Button'
 import LifemapOverview from '../../components/LifemapOverview'
-
+import arrow from '../../../assets/images/selectArrow.png'
 import globalStyles from '../../globalStyles'
 import colors from '../../theme.json'
 
 export class Overview extends Component {
+  state = {
+    filterModalIsOpen: false
+  }
   draftId = this.props.navigation.getParam('draftId')
   survey = this.props.navigation.getParam('survey')
   indicatorsArray = this.survey.surveyStoplightQuestions.map(
@@ -61,6 +70,13 @@ export class Overview extends Component {
     return this.props.navigation.isFocused()
   }
 
+  toggleFilterModal = () => {
+    console.log('toggleFilterModal')
+    this.setState({
+      filterModalIsOpen: !this.state.filterModalIsOpen
+    })
+  }
+
   getMandatoryPrioritiesCount(draft) {
     const potentialPrioritiesCount = draft.indicatorSurveyDataList.filter(
       question => question.value === 1 || question.value === 2
@@ -105,9 +121,14 @@ export class Overview extends Component {
             ) : null}
           </View>
           <View>
-            <Text style={{ ...globalStyles.subline, ...styles.listTitle }}>
-              {t('views.lifemap.allIndicators')}
-            </Text>
+            <TouchableOpacity onPress={this.toggleFilterModal}>
+              <View style={styles.listTitle}>
+                <Text style={globalStyles.subline}>
+                  {t('views.lifemap.allIndicators')}
+                </Text>
+                <Image source={arrow} style={styles.arrow} />
+              </View>
+            </TouchableOpacity>
             <LifemapOverview
               surveyData={this.survey.surveyStoplightQuestions}
               draftData={draft}
@@ -157,14 +178,20 @@ const styles = StyleSheet.create({
   },
   listTitle: {
     backgroundColor: colors.beige,
-    height: 45,
-    lineHeight: 45,
-    flex: 1,
-    textAlign: 'center'
+    height: 47,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row'
   },
   indicatorsContainer: {
     paddingHorizontal: 20,
     paddingBottom: 25
+  },
+  arrow: {
+    marginLeft: 7,
+    marginTop: 3,
+    width: 10,
+    height: 5
   }
 })
 


### PR DESCRIPTION
The Overview screen (which includes the Resume screen) now allows the user to filter the indicators by color, skipped and achievements/priorities.

**To Test**
1. Start a new draft. Go trough the whole process. When doing the stoplight questions have a decent amount of questions from all colors, including skipped.
2. Once on the Overview screen add a few achievements/priorities.
3. Click on the All Indicators text with the arrow above the list of indicators. A select typed popup with overlay should appear. Next to each options should be the number of indicators that will be filtered using it.
4. Choose one of the options and make sure that only the indicators corresponding to that filter appear in the list. There should be no duplicates or empty dimensions.
5. Open the filters again and click on either All or on the transparent overlay outside the options. Both should close the filters and select all indicators.
6. Clicking on any indicator in the list will open adding achievement/priority as normal.

**Also:** The the select popup appearing from the bottom is now separated from Select component. Going through the survey will also be testing if the Select works as expected.

**Note:** The number of dots at the top don't change. That is how I understand the task.

**To do**
1. Change All Indicators test when indicators are changes.
2. Add tests for the Overview and related components.