### PR TITLE
Sync list change

### DIFF
--- a/src/components/DraftListItem.js
+++ b/src/components/DraftListItem.js
@@ -24,9 +24,7 @@ class DraftListItem extends Component {
   }
 
   render() {
-    const linkDisabled =
-      this.props.item.status === 'Synced' ||
-      this.props.item.status === 'Pending sync'
+    const linkDisabled = this.props.item.status !== 'In progress'
     return (
       <TouchableOpacity
         style={{ ...styles.listItem, ...styles.borderBottom }}

--- a/src/components/__tests__/DraftListItem.test.js
+++ b/src/components/__tests__/DraftListItem.test.js
@@ -13,8 +13,8 @@ const createTestProps = props => ({
     familyData: {
       familyMembersList: [
         {
-          firstName: 'Juan', //mandatory
-          lastName: 'Perez' //mandatory
+          firstName: 'Juan',
+          lastName: 'Perez'
         }
       ]
     },
@@ -106,7 +106,7 @@ describe('DraftListItem Component', () => {
       expect(wrapper.find(TouchableOpacity).props().disabled).toBe(true)
       expect(wrapper.find(Icon)).toHaveLength(0)
     })
-    it('enables link when status is Error', () => {
+    it('disables link when status is Error', () => {
       props = createTestProps({
         item: {
           status: 'Sync error',
@@ -122,8 +122,8 @@ describe('DraftListItem Component', () => {
       })
       wrapper = shallow(<DraftListItem {...props} />)
 
-      expect(wrapper.find(TouchableOpacity).props().disabled).toBe(false)
-      expect(wrapper.find(Icon)).toHaveLength(1)
+      expect(wrapper.find(TouchableOpacity).props().disabled).toBe(true)
+      expect(wrapper.find(Icon)).toHaveLength(0)
     })
   })
 })

--- a/src/components/sync/SyncListItem.js
+++ b/src/components/sync/SyncListItem.js
@@ -8,8 +8,7 @@ import globalStyles from '../../globalStyles'
 
 class SyncListItem extends Component {
   render() {
-    const { item } = this.props
-
+    const { item, status } = this.props
     return (
       <View style={[styles.view, styles.borderBottom]}>
         <View style={styles.container}>
@@ -27,14 +26,19 @@ class SyncListItem extends Component {
               : ''
           }`}</Text>
         </View>
-        <Text style={styles.label}>Pending</Text>
+        {status === 'Pending sync' ? (
+          <Text style={styles.label}>Pending</Text>
+        ) : (
+          <Text style={[styles.label, styles.error]}>Sync error</Text>
+        )}
       </View>
     )
   }
 }
 
 SyncListItem.propTypes = {
-  item: PropTypes.object.isRequired
+  item: PropTypes.object.isRequired,
+  status: PropTypes.string.isRequired
 }
 
 const styles = StyleSheet.create({
@@ -59,6 +63,10 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginTop: 5,
     backgroundColor: colors.lightgrey
+  },
+  error: {
+    backgroundColor: colors.palered,
+    color: colors.white
   }
 })
 

--- a/src/screens/Sync.js
+++ b/src/screens/Sync.js
@@ -21,6 +21,10 @@ export class Sync extends Component {
       item => item.type === 'SUBMIT_DRAFT'
     )
 
+    const list = drafts.filter(
+      draft => draft.status === 'Sync error' || draft.status === 'Pending sync'
+    )
+
     return (
       <ScrollView contentContainerStyle={[globalStyles.container, styles.view]}>
         {offline.online && !pendingDrafts.length ? (
@@ -32,13 +36,13 @@ export class Sync extends Component {
         {!offline.online ? (
           <SyncOffline pendingDraftsLength={pendingDrafts.length} />
         ) : null}
-        {pendingDrafts.length ? (
+        {list.length ? (
           <FlatList
             style={{ marginTop: 15 }}
-            data={pendingDrafts}
+            data={list}
             keyExtractor={(item, index) => index.toString()}
             renderItem={({ item }) => (
-              <SyncListItem item={item.payload.familyData} />
+              <SyncListItem item={item.familyData} status={item.status} />
             )}
           />
         ) : null}

--- a/src/screens/__tests__/Sync.test.js
+++ b/src/screens/__tests__/Sync.test.js
@@ -45,9 +45,16 @@ describe('Sync Lifemap View when no questions are skipped', () => {
     it('renders does not render FlatList when outbox is empty', () => {
       expect(wrapper.find(FlatList)).toHaveLength(0)
     })
-    it('renders FlatList when outbox is not empty', () => {
+    it('renders FlatList when draft has status error is not empty', () => {
       props = createTestProps({
-        offline: { outbox: [{ type: 'SUBMIT_DRAFT' }], online: false }
+        drafts: [{ syncedAt: 1, status: 'Sync error' }, { syncedAt: 2 }]
+      })
+      wrapper = shallow(<Sync {...props} />)
+      expect(wrapper.find(FlatList)).toHaveLength(1)
+    })
+    it('renders FlatList when draft has status pending is not empty', () => {
+      props = createTestProps({
+        drafts: [{ syncedAt: 1, status: 'Pending sync' }, { syncedAt: 2 }]
       })
       wrapper = shallow(<Sync {...props} />)
       expect(wrapper.find(FlatList)).toHaveLength(1)


### PR DESCRIPTION
**Describe the changes**
Adds sync errors to sync screen

**To Test**
Produce a fake sync error. Check that it appears on the three variants of the sync screen - offline, in progress and synced.
Check that the sync error item is not clickable on the dashboard anymore.

