### PR TITLE
Priorities messages

### DIFF
--- a/src/components/Tip.js
+++ b/src/components/Tip.js
@@ -11,19 +11,23 @@ class Tip extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      tipVisible: true
+      tipVisible: props.visible || true
     }
   }
 
   hideTip() {
     this.setState({ tipVisible: false })
+
+    if (this.props.onTipClose) {
+      this.props.onTipClose()
+    }
   }
 
   render() {
     return (
       <Modal
         transparent={true}
-        visible={this.state.tipVisible}
+        visible={this.props.visible && this.state.tipVisible}
         onRequestClose={this.hideTip}
         animationType="slide"
         style={{
@@ -71,7 +75,9 @@ class Tip extends Component {
 
 Tip.propTypes = {
   title: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired
+  description: PropTypes.string.isRequired,
+  onTipClose: PropTypes.func,
+  visible: PropTypes.bool
 }
 const styles = StyleSheet.create({
   container: {

--- a/src/components/Tip.js
+++ b/src/components/Tip.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import { StyleSheet, Text, View, Modal } from 'react-native'
 import PropTypes from 'prop-types'
-
 import Button from './Button'
 import colors from '../theme.json'
 import globalStyles from '../globalStyles'
@@ -27,7 +26,7 @@ class Tip extends Component {
     return (
       <Modal
         transparent={true}
-        visible={this.props.visible && this.state.tipVisible}
+        visible={this.props.visible || this.state.tipVisible}
         onRequestClose={this.hideTip}
         animationType="slide"
         style={{

--- a/src/components/__tests__/Tip.test.js
+++ b/src/components/__tests__/Tip.test.js
@@ -34,12 +34,23 @@ describe('Tip Component', () => {
     it('has correct initial state', () => {
       expect(wrapper.instance().state).toEqual({ tipVisible: true })
     })
-    it('clicking Button changes visible state to false', () => {
+    it('clicking Button changes visible state to false and fires onTipClose', () => {
       wrapper
         .find(Button)
         .props()
         .handleClick()
       expect(wrapper.instance().state).toEqual({ tipVisible: false })
+    })
+    it('clicking Button fires onTipClose if providex', () => {
+      props = createTestProps({ onTipClose: jest.fn() })
+      wrapper = shallow(<Tip {...props} />)
+
+      wrapper
+        .find(Button)
+        .props()
+        .handleClick()
+
+      expect(props.onTipClose).toHaveBeenCalledTimes(1)
     })
     it('shows correct title', () => {
       expect(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -21,7 +21,8 @@
     "lifeMaps": "Life Maps",
     "familyInfo": "family info",
     "cachedData": "cached data",
-    "chooseView": "Choose view"
+    "chooseView": "Choose view",
+    "create": "Create"
   },
   "validation": {
     "fieldIsRequired": "This field is required",
@@ -125,7 +126,8 @@
       "yellow": "Yellow",
       "red": "Red",
       "priorities": "Priorities",
-      "achievements": "Achievements"
+      "achievements": "Achievements",
+      "toComplete": "To compmete the lifemap..."
     },
     "modals": {
       "lifeMapWillNotBeSaved": "If you do not enter all details on this page the life map will not be saved!",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -127,7 +127,7 @@
       "red": "Red",
       "priorities": "Priorities",
       "achievements": "Achievements",
-      "toComplete": "To compmete the lifemap..."
+      "toComplete": "To complete the lifemap..."
     },
     "modals": {
       "lifeMapWillNotBeSaved": "If you do not enter all details on this page the life map will not be saved!",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -21,7 +21,8 @@
     "lifeMaps": "Mapas de Vida",
     "familyInfo": "Información de la familia",
     "cachedData": "Datos almacenados",
-    "chooseView": "Elegir vista"
+    "chooseView": "Elegir vista",
+    "create": "Crear"
   },
   "validation": {
     "fieldIsRequired": "Este campo es requerido",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -126,7 +126,8 @@
       "yellow": "Amarillo",
       "red": "Rojo",
       "priorities": "Prioridades",
-      "achievements": "Logros"
+      "achievements": "Logros",
+      "toComplete": "Antes de que se complete el Mapa de Vida...."
     },
     "modals": {
       "lifeMapWillNotBeSaved": "Si no ingresa todos los detalles en esta página, ¡el Mapa de Vida no se guardará!",

--- a/src/screens/__tests__/Overview.test.js
+++ b/src/screens/__tests__/Overview.test.js
@@ -52,7 +52,7 @@ const createTestProps = props => ({
   ...props
 })
 
-describe('Overview Lifemap View when no questions are skipped', () => {
+describe('Overview', () => {
   let wrapper
   let props
   beforeEach(() => {
@@ -68,9 +68,6 @@ describe('Overview Lifemap View when no questions are skipped', () => {
     })
     it('renders LifemapOverview', () => {
       expect(wrapper.find(LifemapOverview)).toHaveLength(1)
-    })
-    it('renders Button', () => {
-      expect(wrapper.find(Button)).toHaveLength(1)
     })
     it('renders Tip', () => {
       expect(wrapper.find(Tip)).toHaveLength(1)
@@ -93,37 +90,6 @@ describe('Overview Lifemap View when no questions are skipped', () => {
   })
 
   describe('functionality', () => {
-    it('calls handleClick function when Button is clicked', () => {
-      wrapper
-        .find(Button)
-        .props()
-        .handleClick()
-      expect(
-        wrapper.instance().props.navigation.navigate
-      ).toHaveBeenCalledTimes(1)
-    })
-
-    it('button is enabled when enough priorities', () => {
-      const props = createTestProps({
-        drafts: [
-          {
-            draftId: 1,
-            priorities: [{ action: 'Some action' }],
-            achievements: [],
-            progress: { screen: 'Location' },
-            indicatorSurveyDataList: [
-              { key: 'phoneNumber', value: 3 },
-              { key: 'education', value: 1 }
-            ]
-          }
-        ]
-      })
-      wrapper = shallow(<Overview {...props} />)
-      expect(wrapper.find(Button).props().disabled).toBe(false)
-    })
-    it('button is disabled when not enough priorities', () => {
-      expect(wrapper.find(Button).props().disabled).toBe(true)
-    })
     it('passes the correct survey data to lifemap overview', () => {
       expect(wrapper.find(LifemapOverview).props().surveyData).toEqual([
         { phoneNumber: 'phoneNumber' },

--- a/src/screens/__tests__/Overview.test.js
+++ b/src/screens/__tests__/Overview.test.js
@@ -54,8 +54,9 @@ const createTestProps = props => ({
 
 describe('Overview Lifemap View when no questions are skipped', () => {
   let wrapper
+  let props
   beforeEach(() => {
-    const props = createTestProps()
+    props = createTestProps()
     wrapper = shallow(<Overview {...props} />)
   })
   describe('rendering', () => {
@@ -145,6 +146,59 @@ describe('Overview Lifemap View when no questions are skipped', () => {
         ]
       })
     })
+
+    it('resumes the draft when Resume is clicked', () => {
+      props = createTestProps({
+        navigation: {
+          navigate: jest.fn(),
+          isFocused: jest.fn(),
+          setParams: jest.fn(),
+          replace: jest.fn(),
+          getParam: jest.fn(param => {
+            if (param === 'draftId') {
+              return 1
+            }
+            if (param === 'survey') {
+              return {
+                id: 2,
+                title: 'Other survey',
+                minimumPriorities: 5,
+                surveyStoplightQuestions: [
+                  { phoneNumber: 'phoneNumber' },
+                  { education: 'education' },
+                  { c: 'c' }
+                ]
+              }
+            }
+            if (param === 'resumeDraft') {
+              return true
+            }
+          })
+        }
+      })
+      wrapper = shallow(<Overview {...props} />)
+
+      wrapper
+        .find('#resume-draft')
+        .props()
+        .handleClick()
+      expect(props.navigation.replace).toHaveBeenCalledTimes(1)
+      expect(props.navigation.replace).toHaveBeenCalledWith('Location', {
+        draftId: 1,
+        socioEconomics: undefined,
+        step: undefined,
+        survey: {
+          id: 2,
+          minimumPriorities: 5,
+          surveyStoplightQuestions: [
+            { phoneNumber: 'phoneNumber' },
+            { education: 'education' },
+            { c: 'c' }
+          ],
+          title: 'Other survey'
+        }
+      })
+    })
   })
 })
 
@@ -187,19 +241,49 @@ describe('Render optimization', () => {
   it('calls addDraftProgress on mount', () => {
     expect(wrapper.instance().props.addDraftProgress).toHaveBeenCalledTimes(1)
   })
-  it('calls onPressBack', () => {
-    const spy = jest.spyOn(wrapper.instance(), 'onPressBack')
-
-    wrapper.instance().onPressBack()
-    expect(spy).toHaveBeenCalledTimes(1)
-    expect(props.navigation.navigate).toHaveBeenCalledTimes(1)
-  })
 
   it('navigates back to skipped screen if there are skipped questions', () => {
     wrapper.instance().onPressBack()
 
     expect(props.navigation.navigate).toHaveBeenCalledWith('Skipped', {
       draftId: 1,
+      survey: {
+        id: 2,
+        minimumPriorities: 5,
+        surveyStoplightQuestions: [
+          { phoneNumber: 'phoneNumber' },
+          { education: 'education' },
+          { c: 'c' }
+        ],
+        title: 'Other survey'
+      }
+    })
+  })
+
+  it('navigates to Question screen when there are no skipped questions', () => {
+    props = createTestProps({
+      drafts: [
+        {
+          draftId: 1,
+          priorities: [{ action: 'Some action' }],
+          achievements: [],
+          progress: { screen: 'Location' },
+          indicatorSurveyDataList: [
+            { key: 'phoneNumber', value: 3 },
+            { key: 'education', value: 1 },
+            { key: 'ind', value: 1 },
+            { key: 'Other ind', value: 2 }
+          ]
+        }
+      ]
+    })
+
+    wrapper = shallow(<Overview {...props} />)
+    wrapper.instance().onPressBack()
+
+    expect(props.navigation.navigate).toHaveBeenCalledWith('Question', {
+      draftId: 1,
+      step: 2,
       survey: {
         id: 2,
         minimumPriorities: 5,

--- a/src/screens/__tests__/Overview.test.js
+++ b/src/screens/__tests__/Overview.test.js
@@ -31,6 +31,9 @@ const createTestProps = props => ({
           ]
         }
       }
+      if (param === 'resumeDraft') {
+        return false
+      }
     })
   },
   drafts: [

--- a/src/screens/__tests__/Overview.test.js
+++ b/src/screens/__tests__/Overview.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { ScrollView } from 'react-native'
+import { ScrollView, View } from 'react-native'
 import { Overview } from '../lifemap/Overview'
 import Button from '../../components/Button'
 import Tip from '../../components/Tip'
@@ -75,6 +75,18 @@ describe('Overview', () => {
     it('renders Tip', () => {
       expect(wrapper.find(Tip)).toHaveLength(1)
     })
+    it('does not render button initially', () => {
+      expect(wrapper.find(Button)).toHaveLength(0)
+    })
+    it('closing tip changes state', () => {
+      wrapper
+        .find(Tip)
+        .props()
+        .onTipClose()
+
+      expect(wrapper.instance().state.tipIsVisible).toBe(false)
+    })
+
     it('does not render Tip when no priorities can be added (all indicators are green)', () => {
       const props = createTestProps({
         drafts: [

--- a/src/screens/lifemap/Overview.js
+++ b/src/screens/lifemap/Overview.js
@@ -84,10 +84,14 @@ export class Overview extends Component {
     })
   }
 
-  getMandatoryPrioritiesCount(draft) {
-    const potentialPrioritiesCount = draft.indicatorSurveyDataList.filter(
+  getPotentialPrioritiesCount(draft) {
+    return draft.indicatorSurveyDataList.filter(
       question => question.value === 1 || question.value === 2
     ).length
+  }
+
+  getMandatoryPrioritiesCount(draft) {
+    const potentialPrioritiesCount = this.getPotentialPrioritiesCount(draft)
 
     return potentialPrioritiesCount > this.survey.minimumPriorities
       ? this.survey.minimumPriorities
@@ -113,6 +117,7 @@ export class Overview extends Component {
             />
             {resumeDraft ? (
               <Button
+                id="resume-draft"
                 style={{
                   marginTop: 20
                 }}
@@ -146,18 +151,39 @@ export class Overview extends Component {
             />
           </View>
 
-          {mandatoryPrioritiesCount ? (
-            <Tip
-              title={t('views.lifemap.beforeTheLifeMapIsCompleted')}
-              description={
-                mandatoryPrioritiesCount === 1
-                  ? t('views.lifemap.youNeedToAddPriotity')
-                  : t('views.lifemap.youNeedToAddPriorities').replace(
-                      '%n',
-                      mandatoryPrioritiesCount
-                    )
-              }
-            />
+          {/*Priorities Tooltip - show only if on resume draft screen*/}
+          {!resumeDraft ? (
+            <View>
+              {/* if there are possible mandatory priorities */}
+              {mandatoryPrioritiesCount ? (
+                <Tip
+                  title={t('views.lifemap.beforeTheLifeMapIsCompleted')}
+                  description={
+                    mandatoryPrioritiesCount === 1
+                      ? t('views.lifemap.youNeedToAddPriotity')
+                      : t('views.lifemap.youNeedToAddPriorities').replace(
+                          '%n',
+                          mandatoryPrioritiesCount
+                        )
+                  }
+                />
+              ) : (
+                <View />
+              )}
+
+              {/* if there are no mandatory priorities, but it's possible to add priorities */}
+              {this.getPotentialPrioritiesCount(draft) &&
+              !mandatoryPrioritiesCount ? (
+                <Tip
+                  title={t('views.lifemap.toComplete')}
+                  description={`${t('general.create')} ${t(
+                    'views.lifemap.priorities'
+                  ).toLowerCase()}!`}
+                />
+              ) : (
+                <View />
+              )}
+            </View>
           ) : (
             <View />
           )}

--- a/src/screens/lifemap/Overview.js
+++ b/src/screens/lifemap/Overview.js
@@ -123,6 +123,7 @@ export class Overview extends Component {
       filterLabel,
       tipIsVisible
     } = this.state
+
     const draft = this.props.drafts.find(item => item.draftId === this.draftId)
     const mandatoryPrioritiesCount = this.getMandatoryPrioritiesCount(draft)
     const resumeDraft = this.props.navigation.getParam('resumeDraft')
@@ -218,6 +219,7 @@ export class Overview extends Component {
         {!resumeDraft && !tipIsVisible ? (
           <View style={{ height: 50 }}>
             <Button
+              id="continue"
               colored
               text={t('general.continue')}
               handleClick={() =>
@@ -225,7 +227,9 @@ export class Overview extends Component {
               }
             />
           </View>
-        ) : null}
+        ) : (
+          <View />
+        )}
 
         {/* Filters modal */}
         <BottomModal

--- a/src/screens/lifemap/Overview.js
+++ b/src/screens/lifemap/Overview.js
@@ -184,7 +184,8 @@ export class Overview extends Component {
                 <Tip
                   title={t('views.lifemap.toComplete')}
                   description={
-                    mandatoryPrioritiesCount === 1
+                    mandatoryPrioritiesCount === 1 ||
+                    mandatoryPrioritiesCount - draft.priorities.length === 1
                       ? t('views.lifemap.youNeedToAddPriotity')
                       : `${t('general.create')} ${mandatoryPrioritiesCount -
                           draft.priorities.length} ${t(

--- a/src/screens/lifemap/Overview.js
+++ b/src/screens/lifemap/Overview.js
@@ -213,9 +213,7 @@ export class Overview extends Component {
                 <View />
               )}
             </View>
-          ) : (
-            <View />
-          )}
+          ) : null}
         </ScrollView>
         {!resumeDraft && !tipIsVisible ? (
           <View style={{ height: 50 }}>
@@ -228,9 +226,7 @@ export class Overview extends Component {
               }
             />
           </View>
-        ) : (
-          <View />
-        )}
+        ) : null}
 
         {/* Filters modal */}
         <BottomModal

--- a/src/screens/lifemap/Overview.js
+++ b/src/screens/lifemap/Overview.js
@@ -24,7 +24,8 @@ export class Overview extends Component {
   state = {
     filterModalIsOpen: false,
     selectedFilter: false,
-    filterLabel: false
+    filterLabel: false,
+    tipIsVisible: true
   }
   draftId = this.props.navigation.getParam('draftId')
   survey = this.props.navigation.getParam('survey')
@@ -98,9 +99,30 @@ export class Overview extends Component {
       : potentialPrioritiesCount
   }
 
+  onTipClose = () => {
+    this.setState({
+      tipIsVisible: false
+    })
+  }
+
+  handleContinue = (mandatoryPrioritiesCount, draft) => {
+    if (mandatoryPrioritiesCount > draft.priorities.length) {
+      this.setState({
+        tipIsVisible: true
+      })
+    } else {
+      this.navigateToScreen('Final')
+    }
+  }
+
   render() {
     const { t } = this.props
-    const { filterModalIsOpen, selectedFilter, filterLabel } = this.state
+    const {
+      filterModalIsOpen,
+      selectedFilter,
+      filterLabel,
+      tipIsVisible
+    } = this.state
     const draft = this.props.drafts.find(item => item.draftId === this.draftId)
     const mandatoryPrioritiesCount = this.getMandatoryPrioritiesCount(draft)
     const resumeDraft = this.props.navigation.getParam('resumeDraft')
@@ -155,17 +177,20 @@ export class Overview extends Component {
           {!resumeDraft ? (
             <View>
               {/* if there are possible mandatory priorities */}
-              {mandatoryPrioritiesCount ? (
+              {mandatoryPrioritiesCount &&
+              mandatoryPrioritiesCount > draft.priorities.length ? (
                 <Tip
-                  title={t('views.lifemap.beforeTheLifeMapIsCompleted')}
+                  title={t('views.lifemap.toComplete')}
                   description={
                     mandatoryPrioritiesCount === 1
                       ? t('views.lifemap.youNeedToAddPriotity')
-                      : t('views.lifemap.youNeedToAddPriorities').replace(
-                          '%n',
-                          mandatoryPrioritiesCount
-                        )
+                      : `${t('general.create')} ${mandatoryPrioritiesCount -
+                          draft.priorities.length} ${t(
+                          'views.lifemap.priorities'
+                        ).toLowerCase()}!`
                   }
+                  visible={tipIsVisible}
+                  onTipClose={this.onTipClose}
                 />
               ) : (
                 <View />
@@ -179,6 +204,8 @@ export class Overview extends Component {
                   description={`${t('general.create')} ${t(
                     'views.lifemap.priorities'
                   ).toLowerCase()}!`}
+                  visible={tipIsVisible}
+                  onTipClose={this.onTipClose}
                 />
               ) : (
                 <View />
@@ -188,15 +215,14 @@ export class Overview extends Component {
             <View />
           )}
         </ScrollView>
-        {!resumeDraft ? (
+        {!resumeDraft && !tipIsVisible ? (
           <View style={{ height: 50 }}>
             <Button
               colored
               text={t('general.continue')}
-              handleClick={() => {
-                this.navigateToScreen('Final')
-              }}
-              disabled={mandatoryPrioritiesCount > draft.priorities.length}
+              handleClick={() =>
+                this.handleContinue(mandatoryPrioritiesCount, draft)
+              }
             />
           </View>
         ) : null}


### PR DESCRIPTION
The overview screen doesn't have any validation apart from disabling the button when there are mandatory priorities that are not set. Now we will show a Tip with the remaining number.

**To Test**
1. Start a new lifemap from a survey that has mandatory priorities (UK survey is one).
2. Go through the survey and answer several stoplight questions with red or yellow
3. Once on the overview screen you should see a tooltip at the bottom with the text `To complete lifemap... Create N Priorities`. No Continue button should be show.
4. Tap the Got it button. The tip should disappear and the sticky continue button should become visible.
5. Click the continue button. Now the tip should again become visible. You should not advance to the Final screen.
6. Exit the draft and enter it again. On the resume screen you should not see any tips. Resume the draft and now you should see the same tooltip.
7. Add a priority to the draft. Click Save. You should not see any tips.
8. Click Continue and now you should see the `To complete lifemap... Create N Priorities` text but now N is smaller by 1. Note: This is how I understand the related issue. We don't bother the user with now do 4, now 3 priorities unless he presses the continue.
9. Add all the necessary priorities to the draft. Now you should be able to Continue to the Final screen. Saving the lifemap should not produce a sync error.
10. Start a new lifemap without mandatory priorities (Sierra Leone is one).
11. Once you reach the Overview screen the Tip should state `To complete lifemap... Create Priorities` - there is no number specified. You should be able to immediately continue.

**A note on tests**
In enzyme I could not get the Continue button to show. This is very weird as I set the proper state and nav param to their appropriate values to show the button and in the test they log as they should, but the state param in the component itself logs as the opposite. I've spend an hour on this alone. This is why I could not test the Continue button.
