### PR TITLE
Hide continue button on keyboard being up

### DIFF
--- a/src/components/StickyFooter.js
+++ b/src/components/StickyFooter.js
@@ -1,22 +1,48 @@
 import React, { Component } from 'react'
-import { View, ScrollView, StyleSheet } from 'react-native'
+import { View, ScrollView, StyleSheet, Keyboard } from 'react-native'
 import Button from './Button'
 import PropTypes from 'prop-types'
 import globalStyles from '../globalStyles'
 
 export default class StickyFooter extends Component {
+  state = {
+    continueVisible: true
+  }
+  toggleContinue = continueVisible => {
+    this.setState({
+      continueVisible
+    })
+  }
+  componentDidMount() {
+    this.keyboardDidShowListener = Keyboard.addListener('keyboardDidShow', () =>
+      this.toggleContinue(false)
+    )
+    this.keyboardDidHideListener = Keyboard.addListener('keyboardDidHide', () =>
+      this.toggleContinue(true)
+    )
+  }
+
+  componentWillUnmount() {
+    this.keyboardDidShowListener.remove()
+    this.keyboardDidHideListener.remove()
+  }
+
   render() {
     return (
       <View style={[globalStyles.background, styles.contentContainer]}>
         <ScrollView>{this.props.children}</ScrollView>
-        <View style={{ height: 50 }}>
-          <Button
-            id="continue"
-            colored
-            text={this.props.continueLabel}
-            handleClick={this.props.handleClick}
-          />
-        </View>
+        {this.state.continueVisible ? (
+          <View style={{ height: 50 }}>
+            <Button
+              id="continue"
+              colored
+              text={this.props.continueLabel}
+              handleClick={this.props.handleClick}
+            />
+          </View>
+        ) : (
+          <View />
+        )}
       </View>
     )
   }

--- a/src/components/__tests__/StickyFooter.test.js
+++ b/src/components/__tests__/StickyFooter.test.js
@@ -32,4 +32,10 @@ describe('Sticky Footer', () => {
       .handleClick()
     expect(props.handleClick).toHaveBeenCalledTimes(1)
   })
+
+  // I wasn't able to simulate Keyboard evets - Dan
+  it('hides the continue button when the keyboard is up', () => {
+    wrapper.setState({ continueVisible: false })
+    expect(wrapper.find(Button)).toHaveLength(0)
+  })
 })


### PR DESCRIPTION
When the keyboard is up on the device, the Continue button is blocking a lot of the view. This pull request aims to resolve that.

**To Test**
1. Open any draft or start a new one. 
2. Go to a page with at least one text input - Primary Participant, Location, Socioeconomics.  Make sure the continue button is stuck to the bottom of the page.
3. Press on top of any text input. The device keyboard will pop up. Make sure the Continue button is not visible while the keyboard is up.