### PR TITLE
Rollover fixes all over the app

### DIFF
--- a/src/components/BottomModal.js
+++ b/src/components/BottomModal.js
@@ -16,6 +16,7 @@ export default class BottomModal extends Component {
           onRequestClose={onRequestClose}
         >
           <TouchableOpacity
+            activeOpacity={1}
             style={[
               styles.overlay,
               {
@@ -32,6 +33,7 @@ export default class BottomModal extends Component {
           onRequestClose={onRequestClose}
         >
           <TouchableOpacity
+            activeOpacity={1}
             id="overlay"
             style={styles.overlay}
             onPress={onEmptyClose}

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -59,7 +59,7 @@ class Button extends Component {
                 : colors.lightdark
             }
         ]}
-        underlayColor={colored ? colors.green : 'transparent'}
+        underlayColor={colored ? colors.green : colors.white}
         activeOpacity={1}
         onPress={handleClick}
         disabled={disabled}
@@ -71,7 +71,7 @@ class Button extends Component {
             <Icon
               name={icon}
               size={21}
-              color={colors.palegreen}
+              color={pressed ? colors.green : colors.palegreen}
               style={styles.icon}
             />
           ) : (

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -11,17 +11,18 @@ import {
 import colors from '../theme.json'
 
 class Button extends Component {
-  defineUnderlayColor = () => {
-    if (this.props.colored) {
-      return colors.green
-    }
+  state = {
+    pressed: false
+  }
 
-    return 'transparent'
+  togglePressedState = () => {
+    this.setState({
+      pressed: !this.state.pressed
+    })
   }
 
   render() {
     const {
-      style,
       borderColor,
       disabled,
       colored,
@@ -29,27 +30,41 @@ class Button extends Component {
       icon,
       handleClick,
       underlined,
-      text
+      text,
+      style
     } = this.props
+
+    const { pressed } = this.state
+
     return (
       <TouchableHighlight
         style={[
           styles.buttonStyle,
-          colored && styles.colored,
-          disabled && styles.disabled,
-          outlined && styles.outlined,
           !colored && !disabled && !outlined && styles.transparent,
           style,
-          outlined && borderColor
-            ? {
-                borderColor
-              }
-            : { borderColor: colors.palegreen }
+          ['colored', 'disabled', 'outlined'].map(item =>
+            this.props[item] ? styles[item] : {}
+          ),
+          {
+            borderColor:
+              outlined && borderColor ? borderColor : colors.palegreen
+          },
+          pressed &&
+            !colored &&
+            !underlined && {
+              borderColor: !borderColor
+                ? colors.green
+                : borderColor === colors.palered
+                ? colors.red
+                : colors.lightdark
+            }
         ]}
+        underlayColor={colored ? colors.green : 'transparent'}
         activeOpacity={1}
-        underlayColor={this.defineUnderlayColor()}
         onPress={handleClick}
         disabled={disabled}
+        onHideUnderlay={this.togglePressedState}
+        onShowUnderlay={this.togglePressedState}
       >
         <View>
           {icon ? (
@@ -72,8 +87,15 @@ class Button extends Component {
                 : colored
                 ? styles.whiteText
                 : styles.greenText,
-
-              underlined ? styles.underlined : {}
+              underlined ? styles.underlined : {},
+              pressed &&
+                !colored && {
+                  color: !borderColor
+                    ? colors.green
+                    : borderColor === colors.palered
+                    ? colors.red
+                    : colors.lightdark
+                }
             ]}
           >
             {text}
@@ -96,6 +118,7 @@ Button.propTypes = {
   style: PropTypes.object
 }
 
+/* eslint-disable react-native/no-unused-styles */
 const styles = StyleSheet.create({
   buttonText: {
     ...Platform.select({
@@ -126,7 +149,6 @@ const styles = StyleSheet.create({
   },
   outlined: {
     flex: 0,
-    fontSize: 14,
     borderRadius: 4,
     borderWidth: 1.5,
     padding: 15

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -66,7 +66,7 @@ class Button extends Component {
         onHideUnderlay={this.togglePressedState}
         onShowUnderlay={this.togglePressedState}
       >
-        <View>
+        <View style={{ flexDirection: 'row' }}>
           {icon ? (
             <Icon
               name={icon}

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -52,11 +52,12 @@ class Button extends Component {
           pressed &&
             !colored &&
             !underlined && {
-              borderColor: !borderColor
-                ? colors.green
-                : borderColor === colors.palered
-                ? colors.red
-                : colors.lightdark
+              borderColor:
+                !borderColor || borderColor === colors.palegreen
+                  ? colors.green
+                  : borderColor === colors.palered
+                  ? colors.red
+                  : colors.lightdark
             }
         ]}
         underlayColor={colored ? colors.green : colors.white}
@@ -90,11 +91,12 @@ class Button extends Component {
               underlined ? styles.underlined : {},
               pressed &&
                 !colored && {
-                  color: !borderColor
-                    ? colors.green
-                    : borderColor === colors.palered
-                    ? colors.red
-                    : colors.lightdark
+                  color:
+                    !borderColor || borderColor === colors.palegreen
+                      ? colors.green
+                      : borderColor === colors.palered
+                      ? colors.red
+                      : colors.lightdark
                 }
             ]}
           >

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import {
   Text,
-  TouchableOpacity,
+  TouchableHighlight,
   StyleSheet,
   Platform,
   View
@@ -11,23 +11,28 @@ import {
 import colors from '../theme.json'
 
 class Button extends Component {
-  defineButtonStyle() {
-    if (this.props.disabled) {
-      return styles.disabled
-    }
+  defineUnderlayColor = () => {
     if (this.props.colored) {
-      return styles.colored
+      return colors.green
     }
-    if (this.props.outlined) {
-      return styles.outlined
-    }
-    return styles.transparent
+
+    return 'transparent'
   }
 
   render() {
-    const { style, borderColor, disabled, colored, outlined } = this.props
+    const {
+      style,
+      borderColor,
+      disabled,
+      colored,
+      outlined,
+      icon,
+      handleClick,
+      underlined,
+      text
+    } = this.props
     return (
-      <TouchableOpacity
+      <TouchableHighlight
         style={[
           styles.buttonStyle,
           colored && styles.colored,
@@ -41,36 +46,40 @@ class Button extends Component {
               }
             : { borderColor: colors.palegreen }
         ]}
-        onPress={this.props.handleClick}
-        disabled={this.props.disabled}
+        activeOpacity={1}
+        underlayColor={this.defineUnderlayColor()}
+        onPress={handleClick}
+        disabled={disabled}
       >
-        {this.props.icon ? (
-          <Icon
-            name={this.props.icon}
-            size={21}
-            color={colors.palegreen}
-            style={styles.icon}
-          />
-        ) : (
-          <View />
-        )}
-        <Text
-          style={[
-            styles.buttonText,
-            outlined && borderColor
-              ? {
-                  color: borderColor
-                }
-              : this.props.colored
+        <View>
+          {icon ? (
+            <Icon
+              name={icon}
+              size={21}
+              color={colors.palegreen}
+              style={styles.icon}
+            />
+          ) : (
+            <View />
+          )}
+          <Text
+            style={[
+              styles.buttonText,
+              outlined && borderColor
+                ? {
+                    color: borderColor
+                  }
+                : colored
                 ? styles.whiteText
                 : styles.greenText,
 
-            this.props.underlined ? styles.underlined : {}
-          ]}
-        >
-          {this.props.text}
-        </Text>
-      </TouchableOpacity>
+              underlined ? styles.underlined : {}
+            ]}
+          >
+            {text}
+          </Text>
+        </View>
+      </TouchableHighlight>
     )
   }
 }

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { TouchableOpacity, StyleSheet } from 'react-native'
+import { TouchableHighlight, StyleSheet } from 'react-native'
 import { CheckBox } from 'react-native-elements'
 import colors from '../theme.json'
 import globalStyles from '../globalStyles'
@@ -18,7 +18,11 @@ class Checkbox extends Component {
     const { containerStyle, textStyle, checkboxColor, showErrors } = this.props
 
     return (
-      <TouchableOpacity style={styles.touchable} onPress={this.onIconPress}>
+      <TouchableHighlight
+        underlayColor={'transparent'}
+        style={styles.touchable}
+        onPress={this.onIconPress}
+      >
         <CheckBox
           disabled
           title={`${this.props.title}${showErrors && !checked ? ' *' : ''}`}
@@ -33,7 +37,7 @@ class Checkbox extends Component {
             showErrors && !checked ? styles.error : {}
           ]}
         />
-      </TouchableOpacity>
+      </TouchableHighlight>
     )
   }
 }

--- a/src/components/Counter.js
+++ b/src/components/Counter.js
@@ -1,40 +1,57 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { TouchableOpacity, StyleSheet, View, Text } from 'react-native'
+import { TouchableHighlight, StyleSheet, View, Text } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
 import colors from '../theme.json'
 import globalStyles from '../globalStyles'
 
 class Counter extends Component {
+  state = {
+    plusPressed: false,
+    minusPressed: false
+  }
+  togglePressedState = (button, state) => {
+    this.setState({
+      [button]: state
+    })
+  }
   render() {
     return (
       <View style={styles.container}>
         <Text style={styles.text}>{this.props.text} </Text>
         <View style={styles.counter}>
           <Text style={styles.count}> {this.props.count} </Text>
-          <TouchableOpacity
+          <TouchableHighlight
+            underlayColor={colors.green}
             style={styles.countButton}
             onPress={() => this.props.editCounter('minus')}
+            onHideUnderlay={() =>
+              this.togglePressedState('minusPressed', false)
+            }
+            onShowUnderlay={() => this.togglePressedState('minusPressed', true)}
           >
             <Icon
               style={styles.icon}
               name="minus"
-              color={colors.green}
+              color={this.state.minusPressed ? colors.white : colors.green}
               size={30}
             />
-          </TouchableOpacity>
-          <TouchableOpacity
+          </TouchableHighlight>
+          <TouchableHighlight
+            underlayColor={colors.green}
             style={styles.countButton}
+            onHideUnderlay={() => this.togglePressedState('plusPressed', false)}
+            onShowUnderlay={() => this.togglePressedState('plusPressed', true)}
             onPress={() => this.props.editCounter('plus')}
           >
             <Icon
               style={styles.icon}
               name="plus"
-              color={colors.green}
+              color={this.state.plusPressed ? colors.white : colors.green}
               size={30}
             />
-          </TouchableOpacity>
+          </TouchableHighlight>
         </View>
       </View>
     )

--- a/src/components/DraftListItem.js
+++ b/src/components/DraftListItem.js
@@ -1,8 +1,9 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Icon from 'react-native-vector-icons/MaterialIcons'
-import { Text, TouchableOpacity, StyleSheet, View } from 'react-native'
+import { Text, StyleSheet, View } from 'react-native'
 import moment from 'moment'
+import ListItem from './ListItem'
 
 import colors from '../theme.json'
 import globalStyles from '../globalStyles'
@@ -26,7 +27,7 @@ class DraftListItem extends Component {
   render() {
     const linkDisabled = this.props.item.status !== 'In progress'
     return (
-      <TouchableOpacity
+      <ListItem
         style={{ ...styles.listItem, ...styles.borderBottom }}
         onPress={this.props.handleClick}
         disabled={linkDisabled}
@@ -53,7 +54,7 @@ class DraftListItem extends Component {
         ) : (
           <View />
         )}
-      </TouchableOpacity>
+      </ListItem>
     )
   }
 }
@@ -66,9 +67,7 @@ DraftListItem.propTypes = {
 const styles = StyleSheet.create({
   listItem: {
     height: 95,
-    paddingTop: 25,
-    paddingBottom: 25,
-    paddingRight: 25,
+    padding: 25,
     alignItems: 'center',
     flexDirection: 'row',
     flex: 1,

--- a/src/components/FilterListItem.js
+++ b/src/components/FilterListItem.js
@@ -1,0 +1,39 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import ListItem from './ListItem'
+import { View, Text, StyleSheet } from 'react-native'
+
+export default class FilterListItem extends Component {
+  render() {
+    return (
+      <ListItem style={styles.row} onPress={this.props.onPress}>
+        <View style={[styles.circle, { backgroundColor: this.props.color }]} />
+        <Text>
+          {this.props.text} ({this.props.amount})
+        </Text>
+      </ListItem>
+    )
+  }
+}
+
+FilterListItem.propTypes = {
+  onPress: PropTypes.func,
+  amount: PropTypes.number,
+  text: PropTypes.string,
+  color: PropTypes.string
+}
+
+const styles = StyleSheet.create({
+  circle: {
+    width: 25,
+    height: 25,
+    borderRadius: 50,
+    marginRight: 30
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 10,
+    paddingHorizontal: 16
+  }
+})

--- a/src/components/IconButton.js
+++ b/src/components/IconButton.js
@@ -45,7 +45,13 @@ export default class IconButton extends Component {
             <Text
               style={[
                 this.props.textStyle,
-                { color: this.state.pressed ? colors.green : colors.palegreen }
+                text && !icon && !communityIcon
+                  ? {}
+                  : {
+                      color: this.state.pressed
+                        ? colors.green
+                        : colors.palegreen
+                    }
               ]}
             >
               {text}

--- a/src/components/IconButton.js
+++ b/src/components/IconButton.js
@@ -1,0 +1,70 @@
+import React, { Component } from 'react'
+import { TouchableHighlight, View, Text, Image } from 'react-native'
+import Icon from 'react-native-vector-icons/MaterialIcons'
+import CommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons'
+import PropTypes from 'prop-types'
+import colors from '../theme.json'
+
+export default class IconButton extends Component {
+  state = {
+    pressed: false
+  }
+  togglePressedState = pressed => {
+    this.setState({
+      pressed
+    })
+  }
+  render() {
+    const { icon, communityIcon, text, imageSource } = this.props
+    return (
+      <TouchableHighlight
+        onPress={this.props.onPress}
+        underlayColor={'transparent'}
+        onHideUnderlay={() => this.togglePressedState(false)}
+        onShowUnderlay={() => this.togglePressedState(true)}
+      >
+        <View style={this.props.style}>
+          {icon && (
+            <Icon
+              name={icon}
+              style={this.props.iconStyle || {}}
+              size={this.props.size || 30}
+              color={this.state.pressed ? colors.green : colors.palegreen}
+            />
+          )}
+          {communityIcon && (
+            <CommunityIcon
+              name={communityIcon}
+              style={this.props.iconStyle || {}}
+              size={this.props.size || 30}
+              color={this.state.pressed ? colors.green : colors.palegreen}
+            />
+          )}
+          {imageSource && <Image source={imageSource} />}
+          {text && (
+            <Text
+              style={[
+                this.props.textStyle,
+                { color: this.state.pressed ? colors.green : colors.palegreen }
+              ]}
+            >
+              {text}
+            </Text>
+          )}
+        </View>
+      </TouchableHighlight>
+    )
+  }
+}
+
+IconButton.propTypes = {
+  style: PropTypes.object,
+  iconStyle: PropTypes.object,
+  icon: PropTypes.string,
+  communityIcon: PropTypes.string,
+  size: PropTypes.number,
+  onPress: PropTypes.func.isRequired,
+  text: PropTypes.string,
+  textStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  imageSource: PropTypes.number
+}

--- a/src/components/LifemapListItem.js
+++ b/src/components/LifemapListItem.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Text, TouchableOpacity, StyleSheet, View, Image } from 'react-native'
+import ListItem from './ListItem'
 
 import colors from '../theme.json'
 import globalStyles from '../globalStyles'
@@ -8,17 +9,14 @@ import stoplight from '../../assets/images/stoplight.png'
 class LifemapListItem extends Component {
   render() {
     return (
-      <TouchableOpacity
-        style={{ ...styles.listItem }}
-        onPress={this.props.handleClick}
-      >
+      <ListItem style={{ ...styles.listItem }} onPress={this.props.handleClick}>
         <Image source={stoplight} style={styles.image} />
         <View style={styles.listItemContainer}>
           <Text style={{ ...globalStyles.p, ...styles.p }}>
             {this.props.name}
           </Text>
         </View>
-      </TouchableOpacity>
+      </ListItem>
     )
   }
 }

--- a/src/components/LifemapOverview.js
+++ b/src/components/LifemapOverview.js
@@ -112,8 +112,11 @@ LifemapOverview.propTypes = {
 }
 
 const styles = StyleSheet.create({
-  container: { ...globalStyles.container, paddingTop: 0, paddingLeft: 25 },
-  dimension: { ...globalStyles.h4, marginVertical: 12 }
+  container: {
+    ...globalStyles.container,
+    padding: 0
+  },
+  dimension: { ...globalStyles.h4, marginHorizontal: 20, marginTop: -20 }
 })
 
 export default LifemapOverview

--- a/src/components/LifemapOverviewListItem.js
+++ b/src/components/LifemapOverviewListItem.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { Text, TouchableOpacity, StyleSheet, View } from 'react-native'
-
+import { Text, StyleSheet, View } from 'react-native'
+import ListItem from './ListItem'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import Icon2 from 'react-native-vector-icons/MaterialCommunityIcons'
 
@@ -27,7 +27,7 @@ class LifemapOverviewListItem extends Component {
 
   render() {
     return (
-      <TouchableOpacity
+      <ListItem
         onPress={this.props.handleClick}
         style={styles.container}
         disabled={!this.props.color}
@@ -79,7 +79,7 @@ class LifemapOverviewListItem extends Component {
             <View />
           )}
         </View>
-      </TouchableOpacity>
+      </ListItem>
     )
   }
 }
@@ -96,7 +96,8 @@ const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
     flexDirection: 'row',
-    flex: 1
+    flex: 1,
+    paddingHorizontal: 20
   },
   listItem: {
     height: 95,

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -1,0 +1,27 @@
+import React, { Component } from 'react'
+import { TouchableHighlight, View } from 'react-native'
+import PropTypes from 'prop-types'
+import colors from '../theme.json'
+
+export default class ListItem extends Component {
+  state = { pressed: false }
+  render() {
+    return (
+      <TouchableHighlight
+        onPress={this.props.onPress}
+        activeOpacity={1}
+        underlayColor={colors.primary}
+        disabled={this.props.disabled}
+      >
+        <View style={this.props.style || {}}>{this.props.children}</View>
+      </TouchableHighlight>
+    )
+  }
+}
+
+ListItem.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  onPress: PropTypes.func.isRequired,
+  style: PropTypes.object,
+  disabled: PropTypes.bool
+}

--- a/src/components/Popup.js
+++ b/src/components/Popup.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { View, StyleSheet, Modal, TouchableOpacity } from 'react-native'
+import { View, StyleSheet, Modal, TouchableHighlight } from 'react-native'
 import colors from '../theme.json'
 
 export default class Popup extends Component {
@@ -14,7 +14,8 @@ export default class Popup extends Component {
         animationType="fade"
         presentationStyle="overFullScreen"
       >
-        <TouchableOpacity
+        <TouchableHighlight
+          underlayColor={'rgba(47,38,28, 0.2)'}
           style={styles.container}
           onPress={onClose}
           id="overlay"
@@ -22,7 +23,7 @@ export default class Popup extends Component {
           <View id="modal" style={styles.modal}>
             {children}
           </View>
-        </TouchableOpacity>
+        </TouchableHighlight>
       </Modal>
     )
   }

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import {
-  TouchableOpacity,
+  TouchableHighlight,
   StyleSheet,
   View,
   Text,
@@ -9,6 +9,7 @@ import {
   ScrollView
 } from 'react-native'
 import BottomModal from './BottomModal'
+import ListItem from './ListItem'
 import countries from 'localized-countries'
 import arrow from '../../assets/images/selectArrow.png'
 import colors from '../theme.json'
@@ -103,7 +104,11 @@ class Select extends Component {
     }
 
     return (
-      <TouchableOpacity onPress={this.toggleDropdown}>
+      <TouchableHighlight
+        underlayColor={'transparent'}
+        activeOpacity={1}
+        onPress={this.toggleDropdown}
+      >
         <View style={styles.wrapper}>
           <View
             style={[
@@ -146,7 +151,7 @@ class Select extends Component {
                 {countrySelect ? (
                   <ScrollView>
                     {countries.map(item => (
-                      <TouchableOpacity
+                      <ListItem
                         key={item.code}
                         onPress={() => this.validateInput(item.code)}
                       >
@@ -158,13 +163,15 @@ class Select extends Component {
                         >
                           {item.label}
                         </Text>
-                      </TouchableOpacity>
+                      </ListItem>
                     ))}
                   </ScrollView>
                 ) : (
                   <ScrollView>
                     {options.map(item => (
-                      <TouchableOpacity
+                      <ListItem
+                        underlayColor={'transparent'}
+                        activeOpacity={1}
                         key={item.value}
                         onPress={() => this.validateInput(item.value)}
                       >
@@ -176,7 +183,7 @@ class Select extends Component {
                         >
                           {item.text}
                         </Text>
-                      </TouchableOpacity>
+                      </ListItem>
                     ))}
                   </ScrollView>
                 )}
@@ -190,7 +197,7 @@ class Select extends Component {
             </Text>
           )}
         </View>
-      </TouchableOpacity>
+      </TouchableHighlight>
     )
   }
 }

--- a/src/components/SkippedListItem.js
+++ b/src/components/SkippedListItem.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Icon from 'react-native-vector-icons/MaterialIcons'
-import { Text, TouchableOpacity, StyleSheet } from 'react-native'
+import { Text, StyleSheet } from 'react-native'
+import ListItem from './ListItem'
 
 import colors from '../theme.json'
 import globalStyles from '../globalStyles'
@@ -9,7 +10,7 @@ import globalStyles from '../globalStyles'
 class SkippedListItem extends Component {
   render() {
     return (
-      <TouchableOpacity
+      <ListItem
         style={{ ...styles.listItem, ...styles.borderBottom }}
         onPress={this.props.handleClick}
       >
@@ -17,7 +18,7 @@ class SkippedListItem extends Component {
           {this.props.item}
         </Text>
         <Icon name="navigate-next" size={23} color={colors.lightdark} />
-      </TouchableOpacity>
+      </ListItem>
     )
   }
 }
@@ -29,9 +30,8 @@ SkippedListItem.propTypes = {
 
 const styles = StyleSheet.create({
   listItem: {
-    paddingTop: 15,
-    paddingBottom: 15,
-    paddingRight: 25,
+    paddingVertical: 15,
+    paddingHorizontal: 25,
     alignItems: 'center',
     flexDirection: 'row',
     flex: 1,

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -5,7 +5,7 @@ import {
   ScrollView,
   Text,
   View,
-  TouchableOpacity
+  TouchableHighlight
 } from 'react-native'
 import Image from './CachedImage'
 import colors from '../theme.json'
@@ -85,7 +85,9 @@ export class Slider extends Component {
                 backgroundColor: colors[slideColors[slide.value]]
               }}
             >
-              <TouchableOpacity
+              <TouchableHighlight
+                activeOpacity={1}
+                underlayColor={'transparent'}
                 style={{
                   ...styles.slide
                 }}
@@ -96,35 +98,37 @@ export class Slider extends Component {
                   })
                 }}
               >
-                <Image
-                  source={slide.url}
-                  style={{
-                    ...styles.image
-                  }}
-                />
-                {this.props.value === slide.value ? (
-                  <View
-                    id="icon-view"
+                <View>
+                  <Image
+                    source={slide.url}
                     style={{
-                      ...styles.iconBig,
-                      backgroundColor: colors[slideColors[this.props.value]]
+                      ...styles.image
+                    }}
+                  />
+                  {this.props.value === slide.value ? (
+                    <View
+                      id="icon-view"
+                      style={{
+                        ...styles.iconBig,
+                        backgroundColor: colors[slideColors[this.props.value]]
+                      }}
+                    >
+                      <Icon name="done" size={56} color={colors.white} />
+                    </View>
+                  ) : (
+                    <View />
+                  )}
+                  <Text
+                    style={{
+                      ...globalStyles.p,
+                      ...styles.text,
+                      color: slide.value === 'YELLOW' ? '#000' : colors.white
                     }}
                   >
-                    <Icon name="done" size={56} color={colors.white} />
-                  </View>
-                ) : (
-                  <View />
-                )}
-                <Text
-                  style={{
-                    ...globalStyles.p,
-                    ...styles.text,
-                    color: slide.value === 'YELLOW' ? '#000' : colors.white
-                  }}
-                >
-                  {slide.description}
-                </Text>
-              </TouchableOpacity>
+                    {slide.description}
+                  </Text>
+                </View>
+              </TouchableHighlight>
             </View>
           ))}
         </ScrollView>

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -1,16 +1,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import {
-  StyleSheet,
-  ScrollView,
-  Text,
-  View,
-  TouchableHighlight
-} from 'react-native'
-import Image from './CachedImage'
+import { ScrollView, View } from 'react-native'
+import SliderItem from './SliderItem'
 import colors from '../theme.json'
-import globalStyles from '../globalStyles'
-import Icon from 'react-native-vector-icons/MaterialIcons'
 import { connect } from 'react-redux'
 import { isPortrait } from '../responsivenessHelpers'
 const slideColors = {
@@ -85,50 +77,16 @@ export class Slider extends Component {
                 backgroundColor: colors[slideColors[slide.value]]
               }}
             >
-              <TouchableHighlight
-                activeOpacity={1}
-                underlayColor={'transparent'}
-                style={{
-                  ...styles.slide
-                }}
+              <SliderItem
+                slide={slide}
                 onPress={() => {
                   this.props.selectAnswer(slide.value)
                   this.setState({
                     selectedColor: colors[slideColors[slide.value]]
                   })
                 }}
-              >
-                <View>
-                  <Image
-                    source={slide.url}
-                    style={{
-                      ...styles.image
-                    }}
-                  />
-                  {this.props.value === slide.value ? (
-                    <View
-                      id="icon-view"
-                      style={{
-                        ...styles.iconBig,
-                        backgroundColor: colors[slideColors[this.props.value]]
-                      }}
-                    >
-                      <Icon name="done" size={56} color={colors.white} />
-                    </View>
-                  ) : (
-                    <View />
-                  )}
-                  <Text
-                    style={{
-                      ...globalStyles.p,
-                      ...styles.text,
-                      color: slide.value === 'YELLOW' ? '#000' : colors.white
-                    }}
-                  >
-                    {slide.description}
-                  </Text>
-                </View>
-              </TouchableHighlight>
+                value={this.props.value}
+              />
             </View>
           ))}
         </ScrollView>
@@ -143,31 +101,6 @@ Slider.propTypes = {
   selectAnswer: PropTypes.func.isRequired,
   dimensions: PropTypes.object
 }
-
-const styles = StyleSheet.create({
-  slide: {
-    width: '100%'
-  },
-  text: {
-    color: colors.white,
-    textAlign: 'center',
-    padding: 15
-  },
-  image: {
-    width: '100%',
-    marginTop: 10
-  },
-  iconBig: {
-    borderRadius: 40,
-    width: 80,
-    height: 80,
-    justifyContent: 'center',
-    alignItems: 'center',
-    alignSelf: 'center',
-    marginTop: -50,
-    marginBottom: -20
-  }
-})
 
 const mapStateToProps = ({ dimensions }) => ({
   dimensions

--- a/src/components/SliderItem.js
+++ b/src/components/SliderItem.js
@@ -1,0 +1,98 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { View, Text, StyleSheet, TouchableHighlight } from 'react-native'
+import Icon from 'react-native-vector-icons/MaterialIcons'
+import colors from '../theme.json'
+import Image from './CachedImage'
+import globalStyles from '../globalStyles'
+
+const slideColors = {
+  1: 'red',
+  2: 'gold',
+  3: 'green'
+}
+
+export default class SliderItem extends Component {
+  state = {
+    pressed: false
+  }
+  togglePressedState = pressed => {
+    this.setState({
+      pressed
+    })
+  }
+  render() {
+    const { slide, value } = this.props
+    return (
+      <TouchableHighlight
+        activeOpacity={1}
+        underlayColor={'transparent'}
+        style={styles.slide}
+        onPress={this.props.onPress}
+        onHideUnderlay={() => this.togglePressedState(false)}
+        onShowUnderlay={() => this.togglePressedState(true)}
+      >
+        <View>
+          <Image
+            source={slide.url}
+            style={{
+              ...styles.image
+            }}
+          />
+
+          <View
+            id="icon-view"
+            style={{
+              ...styles.iconBig,
+              backgroundColor: colors[slideColors[slide.value]],
+              opacity: value === slide.value || this.state.pressed ? 1 : 0
+            }}
+          >
+            <Icon name="done" size={56} color={colors.white} />
+          </View>
+
+          <Text
+            style={{
+              ...globalStyles.p,
+              ...styles.text,
+              color: slide.value === 'YELLOW' ? '#000' : colors.white
+            }}
+          >
+            {slide.description}
+          </Text>
+        </View>
+      </TouchableHighlight>
+    )
+  }
+}
+
+SliderItem.propTypes = {
+  onPress: PropTypes.func,
+  slide: PropTypes.object.isRequired,
+  value: PropTypes.number
+}
+
+const styles = StyleSheet.create({
+  slide: {
+    width: '100%'
+  },
+  text: {
+    color: colors.white,
+    textAlign: 'center',
+    padding: 15
+  },
+  image: {
+    width: '100%',
+    marginTop: 10
+  },
+  iconBig: {
+    borderRadius: 40,
+    width: 80,
+    height: 80,
+    justifyContent: 'center',
+    alignItems: 'center',
+    alignSelf: 'center',
+    marginTop: -50,
+    marginBottom: -20
+  }
+})

--- a/src/components/__tests__/Button.test.js
+++ b/src/components/__tests__/Button.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { shallow } from 'enzyme'
-import { TouchableOpacity, Text } from 'react-native'
+import { TouchableHighlight, Text } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import Button from '../Button'
 import colors from '../../theme.json'
@@ -20,8 +20,8 @@ describe('Button Component', () => {
     wrapper = shallow(<Button {...props} />)
   })
   describe('rendering', () => {
-    it('renders <TouchableOpacity />', () => {
-      expect(wrapper.find(TouchableOpacity)).toHaveLength(1)
+    it('renders <TouchableHighlight />', () => {
+      expect(wrapper.find(TouchableHighlight)).toHaveLength(1)
     })
 
     it('renders <Text />', () => {
@@ -42,7 +42,7 @@ describe('Button Component', () => {
       wrapper = shallow(<Button {...props} />)
 
       expect(
-        wrapper.find(TouchableOpacity).props().style[1].backgroundColor
+        wrapper.find(TouchableHighlight).props().style[1].backgroundColor
       ).toBe(colors.palegreen)
 
       expect(wrapper.find(Text).props().style[1].color).toBe(colors.white)
@@ -51,7 +51,7 @@ describe('Button Component', () => {
   describe('functionality', () => {
     it('should call handleClick onPress', () => {
       wrapper
-        .find(TouchableOpacity)
+        .find(TouchableHighlight)
         .props()
         .onPress()
 

--- a/src/components/__tests__/Button.test.js
+++ b/src/components/__tests__/Button.test.js
@@ -35,18 +35,6 @@ describe('Button Component', () => {
     it('does not render <Icon /> when icon property is not defined', () => {
       expect(wrapper.find(Icon)).toHaveLength(0)
     })
-    it('has proper backgroundColor and text color when passed colored = true', () => {
-      props = createTestProps({
-        colored: true
-      })
-      wrapper = shallow(<Button {...props} />)
-
-      expect(
-        wrapper.find(TouchableHighlight).props().style[1].backgroundColor
-      ).toBe(colors.palegreen)
-
-      expect(wrapper.find(Text).props().style[1].color).toBe(colors.white)
-    })
   })
   describe('functionality', () => {
     it('should call handleClick onPress', () => {

--- a/src/components/__tests__/Button.test.js
+++ b/src/components/__tests__/Button.test.js
@@ -4,7 +4,6 @@ import { shallow } from 'enzyme'
 import { TouchableHighlight, Text } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import Button from '../Button'
-import colors from '../../theme.json'
 
 const createTestProps = props => ({
   ...props,

--- a/src/components/__tests__/Checkbox.test.js
+++ b/src/components/__tests__/Checkbox.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { TouchableOpacity } from 'react-native'
+import { TouchableHighlight } from 'react-native'
 import { CheckBox } from 'react-native-elements'
 import Checkbox from '../Checkbox'
 
@@ -29,7 +29,7 @@ describe('Checkbox Component', () => {
 
     it('calls onPress when icon is pressed', () => {
       wrapper
-        .find(TouchableOpacity)
+        .find(TouchableHighlight)
         .props()
         .onPress()
 

--- a/src/components/__tests__/Counter.test.js
+++ b/src/components/__tests__/Counter.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { TouchableOpacity, Text } from 'react-native'
+import { TouchableHighlight, Text } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 
 import Counter from '../Counter'
@@ -20,8 +20,8 @@ describe('Counter Component', () => {
     wrapper = shallow(<Counter {...props} />)
   })
   describe('rendering', () => {
-    it('renders TouchableOpacity', () => {
-      expect(wrapper.find(TouchableOpacity)).toHaveLength(2)
+    it('renders TouchableHighlight', () => {
+      expect(wrapper.find(TouchableHighlight)).toHaveLength(2)
     })
     it('renders Icon', () => {
       expect(wrapper.find(Icon)).toHaveLength(2)
@@ -33,7 +33,7 @@ describe('Counter Component', () => {
   describe('functionality', () => {
     it('clicking first button calls edit counter with arg "minus"', () => {
       wrapper
-        .find(TouchableOpacity)
+        .find(TouchableHighlight)
         .first()
         .props()
         .onPress()
@@ -43,7 +43,7 @@ describe('Counter Component', () => {
 
     it('clicking second button calls edit counter with arg "plus"', () => {
       wrapper
-        .find(TouchableOpacity)
+        .find(TouchableHighlight)
         .last()
         .props()
         .onPress()

--- a/src/components/__tests__/DateInput.test.js
+++ b/src/components/__tests__/DateInput.test.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { Text } from 'react-native'
-import TextInput from '../TextInput'
 import Select from '../Select'
 import { DateInput } from '../DateInput'
 

--- a/src/components/__tests__/DraftListItem.test.js
+++ b/src/components/__tests__/DraftListItem.test.js
@@ -1,9 +1,10 @@
 import React from 'react'
 
 import { shallow } from 'enzyme'
-import { TouchableOpacity, Text, View } from 'react-native'
+import { Text, View } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import DraftListItem from '../DraftListItem'
+import ListItem from '../ListItem'
 
 const createTestProps = props => ({
   handleClick: jest.fn(),
@@ -32,8 +33,8 @@ describe('DraftListItem Component', () => {
   })
 
   describe('rendering', () => {
-    it('renders <TouchableOpacity />', () => {
-      expect(wrapper.find(TouchableOpacity)).toHaveLength(1)
+    it('renders <ListItem />', () => {
+      expect(wrapper.find(ListItem)).toHaveLength(1)
     })
     it('renders <View />', () => {
       expect(wrapper.find(View)).toHaveLength(1)
@@ -64,7 +65,7 @@ describe('DraftListItem Component', () => {
   describe('functionality', () => {
     it('should call handleClick onPress', () => {
       wrapper
-        .find(TouchableOpacity)
+        .find(ListItem)
         .props()
         .onPress()
       expect(wrapper.instance().props.handleClick).toHaveBeenCalledTimes(1)
@@ -84,7 +85,7 @@ describe('DraftListItem Component', () => {
         }
       })
       wrapper = shallow(<DraftListItem {...props} />)
-      expect(wrapper.find(TouchableOpacity).props().disabled).toBe(true)
+      expect(wrapper.find(ListItem).props().disabled).toBe(true)
       expect(wrapper.find(Icon)).toHaveLength(0)
     })
 
@@ -103,7 +104,7 @@ describe('DraftListItem Component', () => {
         }
       })
       wrapper = shallow(<DraftListItem {...props} />)
-      expect(wrapper.find(TouchableOpacity).props().disabled).toBe(true)
+      expect(wrapper.find(ListItem).props().disabled).toBe(true)
       expect(wrapper.find(Icon)).toHaveLength(0)
     })
     it('disables link when status is Error', () => {
@@ -122,7 +123,7 @@ describe('DraftListItem Component', () => {
       })
       wrapper = shallow(<DraftListItem {...props} />)
 
-      expect(wrapper.find(TouchableOpacity).props().disabled).toBe(true)
+      expect(wrapper.find(ListItem).props().disabled).toBe(true)
       expect(wrapper.find(Icon)).toHaveLength(0)
     })
   })

--- a/src/components/__tests__/DrawerContent.test.js
+++ b/src/components/__tests__/DrawerContent.test.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { Text } from 'react-native'
 import { DrawerContent } from '../navigation/DrawerContent'
 
 const createTestProps = props => ({
@@ -29,20 +28,6 @@ describe('Drawer Content', () => {
     expect(wrapper.find('#username')).toHaveHTML(
       '<react-native-mock>Test</react-native-mock>'
     )
-  })
-
-  it('hilights proper language', () => {
-    expect(wrapper.find('#en').find(Text)).toHaveProp({
-      style: [
-        {
-          fontFamily: 'Poppins',
-          fontWeight: '500',
-          fontSize: 16,
-          lineHeight: 20
-        },
-        { color: '#FFFFFF' }
-      ]
-    })
   })
 
   it('switches language', () => {

--- a/src/components/__tests__/FilterListItem.test.js
+++ b/src/components/__tests__/FilterListItem.test.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { Text } from 'react-native'
+import colors from '../../theme.json'
+import FilterListItem from '../FilterListItem'
+import ListItem from '../ListItem'
+
+const createTestProps = props => ({
+  color: colors.red,
+  amount: 35,
+  onPress: jest.fn(),
+  text: 'Red',
+  ...props
+})
+
+describe('FilterListItem', () => {
+  let wrapper
+  let props
+
+  beforeEach(() => {
+    props = createTestProps()
+    wrapper = shallow(<FilterListItem {...props} />)
+  })
+
+  it('fires onPress when pressed', () => {
+    wrapper
+      .find(ListItem)
+      .props()
+      .onPress()
+
+    expect(wrapper.instance().props.onPress).toHaveBeenCalledTimes(1)
+  })
+
+  it('displays text', () => {
+    expect(wrapper.find(Text)).toHaveLength(1)
+    expect(wrapper.find(Text)).toHaveHTML(
+      '<react-native-mock>Red (35)</react-native-mock>'
+    )
+  })
+})

--- a/src/components/__tests__/IconButton.test.js
+++ b/src/components/__tests__/IconButton.test.js
@@ -1,0 +1,76 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { TouchableHighlight, Text, Image } from 'react-native'
+import Icon from 'react-native-vector-icons/MaterialIcons'
+import CommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons'
+import IconButton from '../IconButton'
+
+const createTestProps = props => ({
+  icon: 'menu',
+  size: 35,
+  onPress: jest.fn(),
+  text: 'Press',
+  ...props
+})
+
+describe('IconButton', () => {
+  let wrapper
+  let props
+
+  beforeEach(() => {
+    props = createTestProps()
+    wrapper = shallow(<IconButton {...props} />)
+  })
+
+  it('is not pressed by default', () => {
+    expect(wrapper).toHaveState({ pressed: false })
+  })
+
+  it('fires onPress when pressed', () => {
+    wrapper
+      .find(TouchableHighlight)
+      .props()
+      .onPress()
+
+    expect(wrapper.instance().props.onPress).toHaveBeenCalledTimes(1)
+  })
+
+  it('toggles between pressed states', () => {
+    wrapper
+      .find(TouchableHighlight)
+      .props()
+      .onShowUnderlay()
+    expect(wrapper).toHaveState({ pressed: true })
+    wrapper
+      .find(TouchableHighlight)
+      .props()
+      .onHideUnderlay()
+    expect(wrapper).toHaveState({ pressed: false })
+  })
+
+  it('displays icon', () => {
+    expect(wrapper.find(Icon)).toHaveLength(1)
+    expect(wrapper.find(Icon)).toHaveProp({ name: 'menu' })
+  })
+
+  it('displays community icon', () => {
+    props = createTestProps({ communityIcon: 'account' })
+    wrapper = shallow(<IconButton {...props} />)
+    expect(wrapper.find(CommunityIcon)).toHaveLength(1)
+    expect(wrapper.find(CommunityIcon)).toHaveProp({ name: 'account' })
+  })
+
+  it('displays text', () => {
+    expect(wrapper.find(Text)).toHaveLength(1)
+    expect(wrapper.find(Text)).toHaveHTML(
+      '<react-native-mock>Press</react-native-mock>'
+    )
+  })
+
+  it('displays image', () => {
+    props = createTestProps({ imageSource: 2 })
+    wrapper = shallow(<IconButton {...props} />)
+    expect(wrapper.find(Image)).toHaveLength(1)
+    expect(wrapper.find(Image)).toHaveProp({ source: 2 })
+  })
+})

--- a/src/components/__tests__/LifemapListItem.test.js
+++ b/src/components/__tests__/LifemapListItem.test.js
@@ -1,9 +1,9 @@
 import React from 'react'
 
 import { shallow } from 'enzyme'
-import { TouchableOpacity, Text, View, Image } from 'react-native'
-
+import { Text, View, Image } from 'react-native'
 import LifemapListItem from '../LifemapListItem'
+import ListItem from '../ListItem'
 
 const createTestProps = props => ({
   handleClick: jest.fn(),
@@ -20,8 +20,8 @@ describe('LifemapListItem Component', () => {
   })
 
   describe('rendering', () => {
-    it('renders <TouchableOpacity />', () => {
-      expect(wrapper.find(TouchableOpacity)).toHaveLength(1)
+    it('renders <ListItem />', () => {
+      expect(wrapper.find(ListItem)).toHaveLength(1)
     })
     it('renders <View />', () => {
       expect(wrapper.find(View)).toHaveLength(1)
@@ -45,7 +45,7 @@ describe('LifemapListItem Component', () => {
   describe('functionality', () => {
     it('should call handleClick onPress', () => {
       wrapper
-        .find(TouchableOpacity)
+        .find(ListItem)
         .props()
         .onPress()
       expect(wrapper.instance().props.handleClick).toHaveBeenCalledTimes(1)

--- a/src/components/__tests__/LifemapOverviewListItem.test.js
+++ b/src/components/__tests__/LifemapOverviewListItem.test.js
@@ -1,10 +1,10 @@
 import React from 'react'
-
 import { shallow } from 'enzyme'
-import { Text, TouchableOpacity } from 'react-native'
+import { Text } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import Icon2 from 'react-native-vector-icons/MaterialCommunityIcons'
 import colors from '../../theme.json'
+import ListItem from '../ListItem'
 import LifemapOverviewListItem from '../LifemapOverviewListItem'
 
 const createTestProps = props => ({
@@ -25,8 +25,8 @@ describe('LifemapOverviewListItem Component', () => {
   })
 
   describe('rendering', () => {
-    it('renders <TouchableOpacity />', () => {
-      expect(wrapper.find(TouchableOpacity)).toHaveLength(1)
+    it('renders <ListItem />', () => {
+      expect(wrapper.find(ListItem)).toHaveLength(1)
     })
 
     it('renders <Text />', () => {

--- a/src/components/__tests__/Navigation.test.js
+++ b/src/components/__tests__/Navigation.test.js
@@ -41,7 +41,7 @@ describe('Navigation', () => {
       wrapper = shallow(<DrawerContent {...props} />)
     })
     it('renders nav image', () => {
-      expect(wrapper.find(Image)).toHaveLength(2)
+      expect(wrapper.find(Image)).toHaveLength(1)
     })
     it('shows proper username', () => {
       expect(wrapper.find('#username')).toHaveHTML(

--- a/src/components/__tests__/Popup.test.js
+++ b/src/components/__tests__/Popup.test.js
@@ -1,12 +1,13 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { TouchableOpacity, Text, Modal } from 'react-native'
+import { Text, Modal } from 'react-native'
 import Popup from '../Popup'
 
 const createTestProps = props => ({
   isOpen: false,
   children: <Text>Modal</Text>,
-  onClose: jest.fn()
+  onClose: jest.fn(),
+  ...props
 })
 
 describe('Popup', () => {

--- a/src/components/__tests__/Select.test.js
+++ b/src/components/__tests__/Select.test.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { TouchableOpacity, Text } from 'react-native'
+import { TouchableHighlight, Text } from 'react-native'
 import Select from '../Select'
+import ListItem from '../ListItem'
 import BottomModal from '../BottomModal'
 
 const createTestProps = props => ({
@@ -35,7 +36,7 @@ describe('Select dropdown', () => {
 
   it('opens a modal when pressed', () => {
     wrapper
-      .find(TouchableOpacity)
+      .find(TouchableHighlight)
       .first()
       .props()
       .onPress()
@@ -49,7 +50,7 @@ describe('Select dropdown', () => {
 
     wrapper
       .find(BottomModal)
-      .find(TouchableOpacity)
+      .find(ListItem)
       .at(1)
       .props()
       .onPress()
@@ -77,7 +78,7 @@ describe('Select dropdown', () => {
     const spy = jest.spyOn(wrapper.instance(), 'validateInput')
 
     wrapper
-      .find(TouchableOpacity)
+      .find(ListItem)
       .first()
       .props()
       .onPress()
@@ -86,18 +87,18 @@ describe('Select dropdown', () => {
       wrapper
         .find(BottomModal)
         .last()
-        .find(TouchableOpacity)
+        .find(ListItem)
     ).toHaveLength(2)
 
     wrapper
       .find(BottomModal)
       .last()
-      .find(TouchableOpacity)
+      .find(ListItem)
       .last()
       .props()
       .onPress()
 
-    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledTimes(2)
     expect(spy).toHaveBeenCalledWith(2)
   })
 

--- a/src/components/__tests__/SkippedListItem.test.js
+++ b/src/components/__tests__/SkippedListItem.test.js
@@ -1,9 +1,10 @@
 import React from 'react'
 
 import { shallow } from 'enzyme'
-import { TouchableOpacity, Text } from 'react-native'
+import { Text } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import SkippedListItem from '../SkippedListItem'
+import ListItem from '../ListItem'
 
 const createTestProps = props => ({
   handleClick: jest.fn(),
@@ -20,8 +21,8 @@ describe('SkippedListItem Component', () => {
   })
 
   describe('rendering', () => {
-    it('renders TouchableOpacity', () => {
-      expect(wrapper.find(TouchableOpacity)).toHaveLength(1)
+    it('renders ListItem', () => {
+      expect(wrapper.find(ListItem)).toHaveLength(1)
     })
     it('renders Text', () => {
       expect(wrapper.find(Text)).toHaveLength(1)
@@ -41,7 +42,7 @@ describe('SkippedListItem Component', () => {
     describe('functionality', () => {
       it('should call handleClick onPress', () => {
         wrapper
-          .find(TouchableOpacity)
+          .find(ListItem)
           .props()
           .onPress()
         expect(wrapper.instance().props.handleClick).toHaveBeenCalledTimes(1)

--- a/src/components/__tests__/Slider.test.js
+++ b/src/components/__tests__/Slider.test.js
@@ -1,9 +1,8 @@
 import React from 'react'
 
 import { shallow } from 'enzyme'
-import { ScrollView, Text, TouchableHighlight } from 'react-native'
-import Image from '../CachedImage'
-import Icon from 'react-native-vector-icons/MaterialIcons'
+import { ScrollView } from 'react-native'
+import SliderItem from '../SliderItem'
 import { Slider } from '../Slider'
 import colors from '../../theme.json'
 
@@ -46,17 +45,8 @@ describe('Slider Component', () => {
     it('renders ScrollView', () => {
       expect(wrapper.find(ScrollView)).toHaveLength(1)
     })
-    it('renders TouchableHighlight', () => {
-      expect(wrapper.find(TouchableHighlight)).toHaveLength(3)
-    })
-    it('renders Image', () => {
-      expect(wrapper.find(Image)).toHaveLength(3)
-    })
-    it('renders Text', () => {
-      expect(wrapper.find(Text)).toHaveLength(3)
-    })
-    it('renders Icon', () => {
-      expect(wrapper.find(Icon)).toHaveLength(1)
+    it('renders SliderItem', () => {
+      expect(wrapper.find(SliderItem)).toHaveLength(3)
     })
   })
 
@@ -66,7 +56,7 @@ describe('Slider Component', () => {
     })
     it('does not change state when user clicks on green slide', () => {
       wrapper
-        .find(TouchableHighlight)
+        .find(SliderItem)
         .at(0)
         .props()
         .onPress()
@@ -74,7 +64,7 @@ describe('Slider Component', () => {
     })
     it('does changes state to yellow when user clicks on yellow slide', () => {
       wrapper
-        .find(TouchableHighlight)
+        .find(SliderItem)
         .at(1)
         .props()
         .onPress()
@@ -83,39 +73,15 @@ describe('Slider Component', () => {
   })
   it('does changes state to red when user clicks on red slide', () => {
     wrapper
-      .find(TouchableHighlight)
+      .find(SliderItem)
       .at(2)
       .props()
       .onPress()
     expect(wrapper.instance().state.selectedColor).toEqual(colors.red)
   })
-  it('renders icon in correct color when value is 1', () => {
-    expect(wrapper.find('#icon-view').props().style.backgroundColor).toBe(
-      colors.red
-    )
-  })
-  it('renders icon in correct color when value is 2', () => {
-    props = createTestProps({ value: 2 })
-    wrapper = shallow(<Slider {...props} />)
-    expect(wrapper.find('#icon-view').props().style.backgroundColor).toBe(
-      colors.gold
-    )
-  })
-  it('renders icon in correct color when value is 3', () => {
-    props = createTestProps({ value: 3 })
-    wrapper = shallow(<Slider {...props} />)
-    expect(wrapper.find('#icon-view').props().style.backgroundColor).toBe(
-      colors.green
-    )
-  })
-  it('does not render icon when value is 0', () => {
-    props = createTestProps({ value: 0 })
-    wrapper = shallow(<Slider {...props} />)
-    expect(wrapper.find(Icon)).toHaveLength(0)
-  })
   it('calls selectAnswer function with the correct argument for green', () => {
     wrapper
-      .find(TouchableHighlight)
+      .find(SliderItem)
       .at(0)
       .props()
       .onPress()
@@ -124,7 +90,7 @@ describe('Slider Component', () => {
   })
   it('calls selectAnswer function with the correct argument for yellow', () => {
     wrapper
-      .find(TouchableHighlight)
+      .find(SliderItem)
       .at(1)
       .props()
       .onPress()
@@ -133,7 +99,7 @@ describe('Slider Component', () => {
   })
   it('calls selectAnswer function with the correct argument for red', () => {
     wrapper
-      .find(TouchableHighlight)
+      .find(SliderItem)
       .at(2)
       .props()
       .onPress()

--- a/src/components/__tests__/Slider.test.js
+++ b/src/components/__tests__/Slider.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { shallow } from 'enzyme'
-import { ScrollView, Text, TouchableOpacity } from 'react-native'
+import { ScrollView, Text, TouchableHighlight } from 'react-native'
 import Image from '../CachedImage'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import { Slider } from '../Slider'
@@ -46,8 +46,8 @@ describe('Slider Component', () => {
     it('renders ScrollView', () => {
       expect(wrapper.find(ScrollView)).toHaveLength(1)
     })
-    it('renders TouchableOpacity', () => {
-      expect(wrapper.find(TouchableOpacity)).toHaveLength(3)
+    it('renders TouchableHighlight', () => {
+      expect(wrapper.find(TouchableHighlight)).toHaveLength(3)
     })
     it('renders Image', () => {
       expect(wrapper.find(Image)).toHaveLength(3)
@@ -66,7 +66,7 @@ describe('Slider Component', () => {
     })
     it('does not change state when user clicks on green slide', () => {
       wrapper
-        .find(TouchableOpacity)
+        .find(TouchableHighlight)
         .at(0)
         .props()
         .onPress()
@@ -74,7 +74,7 @@ describe('Slider Component', () => {
     })
     it('does changes state to yellow when user clicks on yellow slide', () => {
       wrapper
-        .find(TouchableOpacity)
+        .find(TouchableHighlight)
         .at(1)
         .props()
         .onPress()
@@ -83,7 +83,7 @@ describe('Slider Component', () => {
   })
   it('does changes state to red when user clicks on red slide', () => {
     wrapper
-      .find(TouchableOpacity)
+      .find(TouchableHighlight)
       .at(2)
       .props()
       .onPress()
@@ -115,7 +115,7 @@ describe('Slider Component', () => {
   })
   it('calls selectAnswer function with the correct argument for green', () => {
     wrapper
-      .find(TouchableOpacity)
+      .find(TouchableHighlight)
       .at(0)
       .props()
       .onPress()
@@ -124,7 +124,7 @@ describe('Slider Component', () => {
   })
   it('calls selectAnswer function with the correct argument for yellow', () => {
     wrapper
-      .find(TouchableOpacity)
+      .find(TouchableHighlight)
       .at(1)
       .props()
       .onPress()
@@ -133,7 +133,7 @@ describe('Slider Component', () => {
   })
   it('calls selectAnswer function with the correct argument for red', () => {
     wrapper
-      .find(TouchableOpacity)
+      .find(TouchableHighlight)
       .at(2)
       .props()
       .onPress()

--- a/src/components/__tests__/SliderItem.test.js
+++ b/src/components/__tests__/SliderItem.test.js
@@ -1,0 +1,80 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { Text, TouchableHighlight } from 'react-native'
+import Image from '../CachedImage'
+import SliderItem from '../SliderItem'
+import Icon from 'react-native-vector-icons/MaterialIcons'
+import colors from '../../theme.json'
+
+const createTestProps = props => ({
+  slide: {
+    description: 'Our household income is always above 60% of the UK average.',
+    url: 'https://some-url-1.jpg',
+    value: 1
+  },
+  onPress: jest.fn(),
+  ...props
+})
+
+describe('SliderItem Component', () => {
+  let wrapper
+  let props
+  beforeEach(() => {
+    props = createTestProps()
+    wrapper = shallow(<SliderItem {...props} />)
+  })
+
+  it('renders Image', () => {
+    expect(wrapper.find(Image)).toHaveLength(1)
+  })
+  it('renders Text', () => {
+    expect(wrapper.find(Text)).toHaveLength(1)
+  })
+  it('renders Icon', () => {
+    expect(wrapper.find(Icon)).toHaveLength(1)
+  })
+
+  it('renders icon in correct color when value is 1', () => {
+    expect(wrapper.find('#icon-view').props().style.backgroundColor).toBe(
+      colors.red
+    )
+  })
+  it('renders icon in correct color when value is 2', () => {
+    props = createTestProps({
+      slide: {
+        description: '',
+        url: '',
+        value: 2
+      }
+    })
+    wrapper = shallow(<SliderItem {...props} />)
+    expect(wrapper.find('#icon-view').props().style.backgroundColor).toBe(
+      colors.gold
+    )
+  })
+  it('renders icon in correct color when value is 3', () => {
+    props = createTestProps({
+      slide: {
+        description: '',
+        url: '',
+        value: 3
+      }
+    })
+    wrapper = shallow(<SliderItem {...props} />)
+    expect(wrapper.find('#icon-view').props().style.backgroundColor).toBe(
+      colors.green
+    )
+  })
+  it('toggles between pressed states', () => {
+    wrapper
+      .find(TouchableHighlight)
+      .props()
+      .onShowUnderlay()
+    expect(wrapper).toHaveState({ pressed: true })
+    wrapper
+      .find(TouchableHighlight)
+      .props()
+      .onHideUnderlay()
+    expect(wrapper).toHaveState({ pressed: false })
+  })
+})

--- a/src/components/__tests__/SyncListItem.test.js
+++ b/src/components/__tests__/SyncListItem.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { shallow } from 'enzyme'
-import { TouchableOpacity, Text, View } from 'react-native'
+import { Text, View } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import SyncListItem from '../sync/SyncListItem'
 

--- a/src/components/navigation/DrawerContent.js
+++ b/src/components/navigation/DrawerContent.js
@@ -4,7 +4,6 @@ import {
   Image,
   Text,
   StyleSheet,
-  TouchableOpacity,
   View,
   AsyncStorage,
   Platform
@@ -12,10 +11,9 @@ import {
 import { withNamespaces } from 'react-i18next'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
-import CommunityIcon from 'react-native-vector-icons/MaterialCommunityIcons'
-import Icon from 'react-native-vector-icons/MaterialIcons'
 import { url } from '../../config'
 import globalStyles from '../../globalStyles'
+import IconButton from '../IconButton'
 import i18n from '../../i18n'
 import colors from '../../theme.json'
 import { switchLanguage, logout } from '../../redux/actions'
@@ -82,29 +80,27 @@ export class DrawerContent extends Component {
           />
           {/* Language Switcher */}
           <View style={styles.languageSwitch}>
-            <TouchableOpacity id="en" onPress={() => this.changeLanguage('en')}>
-              <Text
-                style={[
-                  globalStyles.h3,
-                  lng === 'en' ? styles.whiteText : styles.greyText
-                ]}
-              >
-                ENG
-              </Text>
-            </TouchableOpacity>
+            <IconButton
+              id="en"
+              onPress={() => this.changeLanguage('en')}
+              text="ENG"
+              textStyle={[
+                globalStyles.h3,
+                lng === 'en' ? styles.whiteText : styles.greyText
+              ]}
+            />
             <Text style={[globalStyles.h3, styles.whiteText]}>
               {'  '}|{'  '}
             </Text>
-            <TouchableOpacity id="es" onPress={() => this.changeLanguage('es')}>
-              <Text
-                style={[
-                  globalStyles.h3,
-                  lng === 'es' ? styles.whiteText : styles.greyText
-                ]}
-              >
-                ESP
-              </Text>
-            </TouchableOpacity>
+            <IconButton
+              id="es"
+              onPress={() => this.changeLanguage('es')}
+              text="ESP"
+              textStyle={[
+                globalStyles.h3,
+                lng === 'es' ? styles.whiteText : styles.greyText
+              ]}
+            />
           </View>
           <Text
             id="username"
@@ -116,7 +112,7 @@ export class DrawerContent extends Component {
         </View>
         <View style={styles.itemsContainer}>
           <View>
-            <TouchableOpacity
+            <IconButton
               id="dashboard"
               style={{
                 ...styles.navItem,
@@ -124,11 +120,11 @@ export class DrawerContent extends Component {
                   this.state.activeTab === 'Dashboard' ? colors.primary : null
               }}
               onPress={() => this.navigateToScreen('Dashboard')}
-            >
-              <Image source={dashboardIcon} />
-              <Text style={styles.label}>{i18n.t('views.dashboard')}</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
+              imageSource={dashboardIcon}
+              text={i18n.t('views.dashboard')}
+              textStyle={styles.label}
+            />
+            <IconButton
               id="surveys"
               style={{
                 ...styles.navItem,
@@ -136,16 +132,12 @@ export class DrawerContent extends Component {
                   this.state.activeTab === 'Surveys' ? colors.primary : null
               }}
               onPress={() => this.navigateToScreen('Surveys')}
-            >
-              <Icon
-                name="swap-calls"
-                style={{ transform: [{ rotate: '90deg' }] }}
-                size={20}
-                color={colors.palegreen}
-              />
-              <Text style={styles.label}>{i18n.t('views.createLifemap')}</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
+              icon="swap-calls"
+              size={20}
+              textStyle={styles.label}
+              text={i18n.t('views.createLifemap')}
+            />
+            <IconButton
               id="sync"
               style={{
                 ...styles.navItem,
@@ -153,28 +145,26 @@ export class DrawerContent extends Component {
                   this.state.activeTab === 'Sync' ? colors.primary : null
               }}
               onPress={() => this.navigateToScreen('Sync')}
-            >
-              <Icon name="sync" size={20} color={colors.palegreen} />
-              <Text style={styles.label}>{i18n.t('views.synced')}</Text>
-            </TouchableOpacity>
+              icon="sync"
+              size={20}
+              text={i18n.t('views.synced')}
+              textStyle={styles.label}
+            />
           </View>
         </View>
         {/* Logout button */}
-        <TouchableOpacity
+        <IconButton
           id="logout"
           style={styles.navItem}
           onPress={() => {
             this.props.navigation.toggleDrawer()
             navigation.setParams({ logoutModalOpen: true })
           }}
-        >
-          <CommunityIcon
-            name="login-variant"
-            size={20}
-            color={colors.palegreen}
-          />
-          <Text style={styles.label}>{i18n.t('views.logout.logout')}</Text>
-        </TouchableOpacity>
+          communityIcon="login-variant"
+          size={20}
+          textStyle={styles.label}
+          text={i18n.t('views.logout.logout')}
+        />
 
         {/* Logout popup */}
         <LogoutPopup
@@ -202,9 +192,11 @@ export class DrawerContent extends Component {
 DrawerContent.propTypes = {
   lng: PropTypes.string,
   switchLanguage: PropTypes.func.isRequired,
+  logout: PropTypes.func.isRequired,
   navigation: PropTypes.object.isRequired,
   user: PropTypes.object.isRequired,
-  drafts: PropTypes.array.isRequired
+  drafts: PropTypes.array.isRequired,
+  env: PropTypes.oneOf(['production', 'demo', 'testing', 'development'])
 }
 
 const mapStateToProps = ({ env, user, drafts }) => ({

--- a/src/components/navigation/DrawerNavigator.js
+++ b/src/components/navigation/DrawerNavigator.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import { createDrawerNavigator } from 'react-navigation'
 import { Platform } from 'react-native'
 import DrawerContentComponent from './DrawerContent'

--- a/src/components/navigation/helpers.js
+++ b/src/components/navigation/helpers.js
@@ -1,18 +1,12 @@
 import React from 'react'
-import {
-  TouchableOpacity,
-  StyleSheet,
-  View,
-  Text,
-  Platform
-} from 'react-native'
+import { StyleSheet, View, Text, Platform } from 'react-native'
 import { AndroidBackHandler } from 'react-navigation-backhandler'
 import { deleteDraft } from '../../redux/actions'
-import Icon from 'react-native-vector-icons/MaterialIcons'
 import store from '../../redux/store'
 import colors from '../../theme.json'
 import Popup from '../Popup'
 import Button from '../Button'
+import IconButton from '../IconButton'
 import globalStyles from '../../globalStyles'
 import i18n from '../../i18n'
 
@@ -46,12 +40,12 @@ export const generateNavOptions = ({ navigation, burgerMenu = true }) => ({
   headerRight:
     navigation.state.routeName !== 'Final' && !burgerMenu ? (
       <View>
-        <TouchableOpacity
+        <IconButton
           style={styles.touchable}
           onPress={() => navigation.setParams({ modalOpen: true })}
-        >
-          <Icon name="close" size={25} color={colors.palegreen} />
-        </TouchableOpacity>
+          icon="close"
+          size={25}
+        />
         <Popup
           isOpen={navigation.getParam('modalOpen')}
           onClose={() => navigation.setParams({ modalOpen: false })}
@@ -107,12 +101,12 @@ export const generateNavOptions = ({ navigation, burgerMenu = true }) => ({
       <View />
     ),
   headerLeft: burgerMenu ? (
-    <TouchableOpacity
+    <IconButton
       style={styles.touchable}
       onPress={() => navigation.toggleDrawer()}
-    >
-      <Icon name="menu" size={30} color={colors.palegreen} />
-    </TouchableOpacity>
+      icon="menu"
+      size={30}
+    />
   ) : (
     <AndroidBackHandler
       onBackPress={() => {
@@ -123,7 +117,7 @@ export const generateNavOptions = ({ navigation, burgerMenu = true }) => ({
       }}
     >
       <View>
-        <TouchableOpacity
+        <IconButton
           style={styles.touchable}
           onPress={() => {
             if (navigation.getParam('deleteOnExit')) {
@@ -135,9 +129,9 @@ export const generateNavOptions = ({ navigation, burgerMenu = true }) => ({
                 : navigation.goBack()
             }
           }}
-        >
-          <Icon name="arrow-back" size={25} color={colors.palegreen} />
-        </TouchableOpacity>
+          icon="arrow-back"
+          size={25}
+        />
         <Popup
           isOpen={navigation.getParam('backModalOpen')}
           onClose={() => navigation.setParams({ backModalOpen: false })}

--- a/src/screens/Dashboard.js
+++ b/src/screens/Dashboard.js
@@ -94,7 +94,7 @@ export class Dashboard extends Component {
               </View>
             ) : null}
             <FlatList
-              style={{ ...styles.background, paddingLeft: 25 }}
+              style={{ ...styles.background }}
               data={list}
               keyExtractor={(item, index) => index.toString()}
               renderItem={({ item }) => (

--- a/src/screens/__tests__/Question.test.js
+++ b/src/screens/__tests__/Question.test.js
@@ -4,10 +4,11 @@ import {
   ScrollView,
   Text,
   ProgressBarAndroid,
-  TouchableOpacity
+  TouchableHighlight
 } from 'react-native'
 import { Question } from '../lifemap/Question'
 import SliderComponent from '../../components/Slider'
+import IconButton from '../../components/IconButton'
 
 const createTestProps = props => ({
   t: value => value,
@@ -52,7 +53,7 @@ describe('Question View', () => {
       expect(wrapper.find(ScrollView)).toHaveLength(1)
     })
     it('renders Text', () => {
-      expect(wrapper.find(Text)).toHaveLength(3)
+      expect(wrapper.find(Text)).toHaveLength(2)
     })
     it('renders ProgressBarAndroid', () => {
       expect(wrapper.find(ProgressBarAndroid)).toHaveLength(1)
@@ -76,21 +77,21 @@ describe('Question View', () => {
     it('calls selectAnswer with argument 0 when link is clicked', () => {
       const spy = jest.spyOn(wrapper.instance(), 'selectAnswer')
       wrapper
-        .find(TouchableOpacity)
+        .find(IconButton)
         .props()
         .onPress()
 
       expect(spy).toHaveBeenCalledTimes(1)
       expect(spy).toHaveBeenCalledWith(0)
     })
-    it('renders TouchableOpacity when indicator is not required', () => {
-      expect(wrapper.find(TouchableOpacity)).toHaveLength(1)
+    it('renders IconButton when indicator is not required', () => {
+      expect(wrapper.find(IconButton)).toHaveLength(1)
     })
     it('renders Text when indicator is required', () => {
       survey.surveyStoplightQuestions[0].required = true
       const props = createTestProps()
       wrapper = shallow(<Question {...props} />)
-      expect(wrapper.find(TouchableOpacity)).toHaveLength(0)
+      expect(wrapper.find(TouchableHighlight)).toHaveLength(0)
     })
   })
 })

--- a/src/screens/lifemap/Location.js
+++ b/src/screens/lifemap/Location.js
@@ -5,7 +5,7 @@ import {
   ActivityIndicator,
   Text,
   Image,
-  TouchableOpacity,
+  TouchableHighlight,
   NetInfo
 } from 'react-native'
 import { connect } from 'react-redux'
@@ -307,13 +307,15 @@ export class Location extends Component {
                   color={colors.palegreen}
                 />
               ) : (
-                <TouchableOpacity
+                <TouchableHighlight
                   id="centerMap"
+                  underlayColor={'transparent'}
+                  activeOpacity={1}
                   style={styles.center}
                   onPress={this.getDeviceLocation}
                 >
                   <Image source={center} style={{ width: 21, height: 21 }} />
-                </TouchableOpacity>
+                </TouchableHighlight>
               )}
             </View>
           ) : (

--- a/src/screens/lifemap/Overview.js
+++ b/src/screens/lifemap/Overview.js
@@ -1,12 +1,5 @@
 import React, { Component } from 'react'
-import {
-  StyleSheet,
-  ScrollView,
-  View,
-  Text,
-  Image,
-  TouchableOpacity
-} from 'react-native'
+import { StyleSheet, View, Text, Image, TouchableHighlight } from 'react-native'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { withNamespaces } from 'react-i18next'
@@ -14,6 +7,7 @@ import { addDraftProgress } from '../../redux/actions'
 import StickyFooter from '../../components/StickyFooter'
 import LifemapVisual from '../../components/LifemapVisual'
 import Button from '../../components/Button'
+import FilterListItem from '../../components/FilterListItem'
 import LifemapOverview from '../../components/LifemapOverview'
 import BottomModal from '../../components/BottomModal'
 import arrow from '../../../assets/images/selectArrow.png'
@@ -185,14 +179,19 @@ export class Overview extends Component {
             ) : null}
           </View>
           <View>
-            <TouchableOpacity id="filters" onPress={this.toggleFilterModal}>
+            <TouchableHighlight
+              id="filters"
+              underlayColor={'transparent'}
+              activeOpacity={1}
+              onPress={this.toggleFilterModal}
+            >
               <View style={styles.listTitle}>
                 <Text style={globalStyles.subline}>
                   {filterLabel || t('views.lifemap.allIndicators')}
                 </Text>
                 <Image source={arrow} style={styles.arrow} />
               </View>
-            </TouchableOpacity>
+            </TouchableHighlight>
             <LifemapOverview
               surveyData={this.survey.surveyStoplightQuestions}
               draftData={draft}
@@ -213,82 +212,53 @@ export class Overview extends Component {
               </Text>
 
               {/* All */}
-              <TouchableOpacity
+              <FilterListItem
                 id="all"
-                style={styles.row}
                 onPress={() => this.selectFilter(false)}
-              >
-                <View style={[styles.circle, { backgroundColor: '#EAD1AF' }]} />
-                <Text>
-                  {t('views.lifemap.allIndicators')} (
-                  {draft.indicatorSurveyDataList.length})
-                </Text>
-              </TouchableOpacity>
+                color={'#EAD1AF'}
+                text={t('views.lifemap.allIndicators')}
+                amount={draft.indicatorSurveyDataList.length}
+              />
 
               {/* Green */}
-              <TouchableOpacity
+              <FilterListItem
                 id="green"
-                style={styles.row}
                 onPress={() => this.selectFilter(3, t('views.lifemap.green'))}
-              >
-                <View
-                  style={[styles.circle, { backgroundColor: colors.green }]}
-                />
-                <Text>
-                  {t('views.lifemap.green')} (
-                  {
-                    draft.indicatorSurveyDataList.filter(
-                      item => item.value === 3
-                    ).length
-                  }
-                  )
-                </Text>
-              </TouchableOpacity>
+                color={colors.green}
+                text={t('views.lifemap.green')}
+                amount={
+                  draft.indicatorSurveyDataList.filter(item => item.value === 3)
+                    .length
+                }
+              />
 
               {/* Yellow */}
-              <TouchableOpacity
+              <FilterListItem
                 id="yellow"
-                style={styles.row}
                 onPress={() => this.selectFilter(2, t('views.lifemap.yellow'))}
-              >
-                <View
-                  style={[styles.circle, { backgroundColor: colors.gold }]}
-                />
-                <Text>
-                  {t('views.lifemap.yellow')} (
-                  {
-                    draft.indicatorSurveyDataList.filter(
-                      item => item.value === 2
-                    ).length
-                  }
-                  )
-                </Text>
-              </TouchableOpacity>
+                color={colors.gold}
+                text={t('views.lifemap.yellow')}
+                amount={
+                  draft.indicatorSurveyDataList.filter(item => item.value === 2)
+                    .length
+                }
+              />
 
               {/* Red */}
-              <TouchableOpacity
+              <FilterListItem
                 id="red"
-                style={styles.row}
                 onPress={() => this.selectFilter(1, t('views.lifemap.red'))}
-              >
-                <View
-                  style={[styles.circle, { backgroundColor: colors.red }]}
-                />
-                <Text>
-                  {t('views.lifemap.red')} (
-                  {
-                    draft.indicatorSurveyDataList.filter(
-                      item => item.value === 1
-                    ).length
-                  }
-                  )
-                </Text>
-              </TouchableOpacity>
+                color={colors.red}
+                text={t('views.lifemap.red')}
+                amount={
+                  draft.indicatorSurveyDataList.filter(item => item.value === 1)
+                    .length
+                }
+              />
 
               {/* Priorities/achievements */}
-              <TouchableOpacity
+              <FilterListItem
                 id="priorities"
-                style={styles.row}
                 onPress={() =>
                   this.selectFilter(
                     'priorities',
@@ -297,38 +267,26 @@ export class Overview extends Component {
                     )}`
                   )
                 }
-              >
-                <View
-                  style={[styles.circle, { backgroundColor: colors.blue }]}
-                />
-                <Text>
-                  {t('views.lifemap.priorities')} &{' '}
-                  {t('views.lifemap.achievements')} (
-                  {draft.priorities.length + draft.achievements.length})
-                </Text>
-              </TouchableOpacity>
+                color={colors.blue}
+                text={`${t('views.lifemap.priorities')} & ${t(
+                  'views.lifemap.achievements'
+                )}`}
+                amount={draft.priorities.length + draft.achievements.length}
+              />
 
               {/* Skipped */}
-              <TouchableOpacity
+              <FilterListItem
                 id="skipped"
-                style={styles.row}
                 onPress={() =>
                   this.selectFilter(0, t('views.skippedIndicators'))
                 }
-              >
-                <View
-                  style={[styles.circle, { backgroundColor: colors.palegrey }]}
-                />
-                <Text>
-                  {t('views.skippedIndicators')} (
-                  {
-                    draft.indicatorSurveyDataList.filter(
-                      item => item.value === 0
-                    ).length
-                  }
-                  )
-                </Text>
-              </TouchableOpacity>
+                color={colors.palegrey}
+                text={t('views.skippedIndicators')}
+                amount={
+                  draft.indicatorSurveyDataList.filter(item => item.value === 0)
+                    .length
+                }
+              />
             </View>
           </BottomModal>
         </View>
@@ -362,24 +320,18 @@ const styles = StyleSheet.create({
     height: 5
   },
   dropdown: {
-    padding: 16,
+    paddingVertical: 16,
     position: 'absolute',
     bottom: 0,
     left: 0,
     right: 0,
     backgroundColor: colors.white
   },
-  modalTitle: { color: colors.grey, fontWeight: '300', marginBottom: 25 },
-  circle: {
-    width: 25,
-    height: 25,
-    borderRadius: 50,
-    marginRight: 30
-  },
-  row: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 23
+  modalTitle: {
+    color: colors.grey,
+    fontWeight: '300',
+    marginBottom: 15,
+    marginLeft: 16
   }
 })
 

--- a/src/screens/lifemap/Question.js
+++ b/src/screens/lifemap/Question.js
@@ -4,9 +4,9 @@ import {
   ScrollView,
   Text,
   ProgressBarAndroid,
-  View,
-  TouchableOpacity
+  View
 } from 'react-native'
+import IconButton from '../../components/IconButton'
 
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
@@ -164,11 +164,11 @@ export class Question extends Component {
           {this.indicator.required ? (
             <Text>{t('views.lifemap.responseRequired')}</Text>
           ) : (
-            <TouchableOpacity onPress={() => this.selectAnswer(0)}>
-              <Text style={styles.link}>
-                {t('views.lifemap.skipThisQuestion')}
-              </Text>
-            </TouchableOpacity>
+            <IconButton
+              text={t('views.lifemap.skipThisQuestion')}
+              textStyle={styles.link}
+              onPress={() => this.selectAnswer(0)}
+            />
           )}
         </View>
       </ScrollView>

--- a/src/screens/lifemap/Skipped.js
+++ b/src/screens/lifemap/Skipped.js
@@ -70,7 +70,7 @@ export class Skipped extends Component {
         />
 
         <FlatList
-          style={{ ...styles.background, paddingLeft: 25 }}
+          style={{ ...styles.background }}
           data={skippedQuestions}
           keyExtractor={(item, index) => index.toString()}
           renderItem={({ item }) => (


### PR DESCRIPTION
There are 3 major issue being fixed with this pull request:
- Interactive elements (buttons/icons) will no longer fade out when tapped, but will increase their color intensity. For example `palegreen` will go to `green`.
- List items like Drafts and Surveys will have a background active color
- Stoplight Questions will show the Check circle icon when tapped

**To Test**
1. Go to Dashboard
2. Hold tap on the Create a life map button, without letting go. It's background should become darker (`colors.green`).
3. Hold tap on the burger menu. It's color should again be darkened.
4. Open the menu and repeat the same steps for the links and logout button.
5. Open logout modal. Hold tapping on the Yes button should make it darker red. The now should be a darker grey.
6. Create a new lifemap. In the choose survey screen, hold tap on any survey item from the list. It should have a grey background instead of fading out.
7. Go to Primary participant. Open any select. The options should have a grey background on hold press.
8. Go to the stoplight questions. Hold tapping an indicator should show the circle thick icon with the appropriate color (as if already having a value).
9. Go through the lifemap skipping a few questions
10. Go to skipped questions. Hold tapping a question should produce the same effect as with surveys on step 6.
11. Go to overview and try adding a priority. Tapping the number of months (counter elements) should make them green background on white + or -.
12. From Overview screen open the open filters and check if again the same effect as with surveys from step 6 is present when tapping.

@IvaKop This pull request also includes the overview filters list item being separated into its own component. We discussed that I will do this without an issue.