### PR TITLE
Move family count to family participant screen

### DIFF
--- a/src/screens/__tests__/FamilyMembersNames.test.js
+++ b/src/screens/__tests__/FamilyMembersNames.test.js
@@ -62,9 +62,6 @@ describe('FamilyMembersNames View', () => {
         continueLabel: 'general.continue'
       })
     })
-    it('renders Select', () => {
-      expect(wrapper.find(Select)).toHaveLength(1)
-    })
     it('renders TextInput', () => {
       expect(wrapper.find(TextInput)).toHaveLength(2)
     })
@@ -96,9 +93,7 @@ describe('FamilyMembersNames View', () => {
       expect(spy).toHaveBeenCalledTimes(1)
     })
   })
-  it('gives Select the proper value', () => {
-    expect(wrapper.find(Select).props().value).toBe(2)
-  })
+
   it('makes first TextInput is readonly', () => {
     expect(
       wrapper
@@ -135,35 +130,6 @@ describe('FamilyMembersNames View', () => {
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
-  it('changes family members count', () => {
-    wrapper
-      .find('#familyMembersCount')
-      .props()
-      .onChange(4, 'familyMembersCount')
-
-    expect(wrapper.instance().props.addSurveyData).toHaveBeenCalledTimes(1)
-    expect(wrapper.instance().props.addSurveyData).toHaveBeenCalledWith(
-      4,
-      'familyData',
-      {
-        familyMembersCount: 4
-      }
-    )
-  })
-  it('remove excess family members when count is lowered', () => {
-    wrapper
-      .find('#familyMembersCount')
-      .props()
-      .onChange(1, 'familyMembersCount')
-
-    expect(wrapper.instance().props.removeFamilyMembers).toHaveBeenCalledTimes(
-      1
-    )
-    expect(wrapper.instance().props.removeFamilyMembers).toHaveBeenCalledWith(
-      4,
-      1
-    )
-  })
   it('shows and hides errors', () => {
     wrapper.instance().detectError(true, 'test')
 

--- a/src/screens/__tests__/FamilyParticipant.test.js
+++ b/src/screens/__tests__/FamilyParticipant.test.js
@@ -13,6 +13,8 @@ const createTestProps = props => ({
   deleteDraft: jest.fn(),
   addSurveyFamilyMemberData: jest.fn(),
   addDraftProgress: jest.fn(),
+  addSurveyData: jest.fn(),
+  removeFamilyMembers: jest.fn(),
   navigation: {
     navigate: jest.fn(),
     getParam: param => (param === 'draftId' ? null : 1),
@@ -147,7 +149,7 @@ describe('Family Participant View', () => {
       expect(wrapper.find(TextInput)).toHaveLength(5)
     })
     it('renders Select', () => {
-      expect(wrapper.find(Select)).toHaveLength(3)
+      expect(wrapper.find(Select)).toHaveLength(4)
     })
     it('renders DateInput', () => {
       expect(wrapper.find(DateInputComponent)).toHaveLength(1)
@@ -232,6 +234,85 @@ describe('Family Participant View', () => {
       wrapper.instance().detectError(false, 'phoneNumber')
       expect(wrapper.instance().errorsDetected).toEqual([])
     })
+  })
+})
+
+describe('Family Member Count Functionality', () => {
+  let wrapper
+  let props
+  beforeEach(() => {
+    props = createTestProps({
+      navigation: {
+        navigate: jest.fn(),
+        getParam: param => (param === 'draftId' ? 4 : 1),
+        setParams: jest.fn(),
+        reset: jest.fn(),
+        isFocused: jest.fn()
+      },
+      drafts: [
+        {
+          draftId: 4,
+          surveyId: 1,
+          economicSurveyDataList: [
+            { key: 'educationPersonMostStudied', value: 'SCHOOL-COMPLETE' },
+            { key: 'receiveStateIncome', value: 'NO' },
+            { key: 'currency', value: 'GBP/Pound Sterling' },
+            { key: 'areaOfResidence', value: 'URBAN' }
+          ],
+
+          indicatorSurveyDataList: [
+            { key: 'insurance', value: 1 },
+            { key: 'entertainmentAndRecreation', value: 3 },
+            { key: 'stableHousing', value: 2 }
+          ],
+          familyData: {
+            countFamilyMembers: 2,
+            familyMembersList: [
+              {
+                firstName: 'Juan',
+                lastName: 'Perez'
+              },
+              {
+                firstName: 'Ana'
+              }
+            ]
+          }
+        }
+      ]
+    })
+    wrapper = shallow(<FamilyParticipant {...props} />)
+  })
+  it('gives Select the proper value', () => {
+    expect(wrapper.find('#familyMembersCount').props().value).toBe(2)
+  })
+  it('changes family members count', () => {
+    wrapper
+      .find('#familyMembersCount')
+      .props()
+      .onChange(4, 'familyMembersCount')
+
+    expect(wrapper.instance().props.addSurveyData).toHaveBeenCalledTimes(1)
+    expect(wrapper.instance().props.addSurveyData).toHaveBeenCalledWith(
+      4,
+      'familyData',
+      {
+        familyMembersCount: 4
+      }
+    )
+  })
+  it('remove excess family members when count is lowered', () => {
+    wrapper
+      .find('#familyMembersCount')
+      .props()
+      .onChange(1, 'familyMembersCount')
+
+    expect(wrapper.instance().props.removeFamilyMembers).toHaveBeenCalledTimes(
+      1
+    )
+    expect(wrapper.instance().props.removeFamilyMembers).toHaveBeenCalledWith(
+      4,
+      1
+    )
   })
 })
 

--- a/src/screens/lifemap/FamilyMembersNames.js
+++ b/src/screens/lifemap/FamilyMembersNames.js
@@ -3,9 +3,7 @@ import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { withNamespaces } from 'react-i18next'
 import {
-  addSurveyData,
   addSurveyFamilyMemberData,
-  removeFamilyMembers,
   addDraftProgress
 } from '../../redux/actions'
 import StickyFooter from '../../components/StickyFooter'
@@ -57,15 +55,10 @@ export class FamilyMembersNames extends Component {
         showErrors: true
       })
     } else {
-      this.getFieldValue('countFamilyMembers') > 1
-        ? this.props.navigation.navigate('FamilyMembersGender', {
-            draftId: this.draftId,
-            survey: this.survey
-          })
-        : this.props.navigation.navigate('Location', {
-            draftId: this.draftId,
-            survey: this.survey
-          })
+      this.props.navigation.navigate('FamilyMembersGender', {
+        draftId: this.draftId,
+        survey: this.survey
+      })
     }
   }
   getDraft = () =>
@@ -80,37 +73,6 @@ export class FamilyMembersNames extends Component {
     return draft.familyData[field]
   }
 
-  addFamilyCount = (text, field) => {
-    // if reducing the number of family members remove the rest
-    if (text && this.getFieldValue('countFamilyMembers') > text) {
-      const index = text === -1 ? 1 : text
-      this.props.removeFamilyMembers(this.draftId, index)
-
-      // also remove these from the errors array
-      for (
-        var i = index - 1;
-        i < this.getFieldValue('countFamilyMembers') - 1;
-        i++
-      ) {
-        this.errorsDetected = this.errorsDetected.filter(
-          item => item !== `${i}`
-        )
-      }
-
-      this.setState({
-        errorsDetected: this.errorsDetected
-      })
-    }
-
-    this.setState({
-      showErrors: false
-    })
-
-    this.props.addSurveyData(this.draftId, 'familyData', {
-      [field]: text
-    })
-  }
-
   addFamilyMemberName(name, index) {
     this.props.addSurveyFamilyMemberData({
       id: this.draftId,
@@ -121,19 +83,6 @@ export class FamilyMembersNames extends Component {
       }
     })
   }
-
-  getFamilyMembersCountArray = t => [
-    { text: t('views.family.onlyPerson'), value: 1 },
-    ...Array.from(new Array(24), (val, index) => ({
-      value: index + 2,
-      text: `${index + 2}`
-    })),
-
-    {
-      text: t('views.family.preferNotToSay'),
-      value: -1
-    }
-  ]
 
   render() {
     const { t } = this.props
@@ -153,18 +102,6 @@ export class FamilyMembersNames extends Component {
         handleClick={() => this.handleClick(draft)}
         continueLabel={t('general.continue')}
       >
-        <Select
-          id="familyMembersCount"
-          required
-          onChange={this.addFamilyCount}
-          label={t('views.family.peopleLivingInThisHousehold')}
-          placeholder={t('views.family.peopleLivingInThisHousehold')}
-          field="countFamilyMembers"
-          value={this.getFieldValue('countFamilyMembers') || ''}
-          detectError={this.detectError}
-          showErrors={showErrors}
-          options={this.getFamilyMembersCountArray(t)}
-        />
         <TextInput
           validation="string"
           field=""
@@ -203,16 +140,12 @@ FamilyMembersNames.propTypes = {
   drafts: PropTypes.array,
   t: PropTypes.func.isRequired,
   navigation: PropTypes.object.isRequired,
-  addSurveyData: PropTypes.func.isRequired,
   addSurveyFamilyMemberData: PropTypes.func.isRequired,
-  removeFamilyMembers: PropTypes.func.isRequired,
   addDraftProgress: PropTypes.func.isRequired
 }
 
 const mapDispatchToProps = {
-  addSurveyData,
   addSurveyFamilyMemberData,
-  removeFamilyMembers,
   addDraftProgress
 }
 

--- a/src/screens/lifemap/Location.js
+++ b/src/screens/lifemap/Location.js
@@ -215,7 +215,7 @@ export class Location extends Component {
         survey: this.survey
       })
     } else
-      this.props.navigation.navigate('FamilyMembersNames', {
+      this.props.navigation.navigate('FamilyParticipant', {
         draftId: this.draftId,
         survey: this.survey
       })


### PR DESCRIPTION
**Describe the changes**
This moves the family count select to the family participant screen

**To Test**
See that the data is stored correctly in the draft.
See that familyParticipant screen navigates to location if count < 1, otherwise you get to the family names screen. See that the select is removed from the family names screen. See that clicking back on the Location screen takes you back to the appropriate screen.
See that the additional family members are deleted from the draft if the count is lowered (as it worked before)
