### PR TITLE
Show not synced families in family list

### DIFF
--- a/src/components/FamiliesListItem.js
+++ b/src/components/FamiliesListItem.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { Text, TouchableOpacity, StyleSheet, View, Image } from 'react-native'
+import { Text, StyleSheet, View } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import moment from 'moment'
 
@@ -11,23 +11,24 @@ import ListItem from './ListItem'
 class FamiliesListItem extends Component {
   render() {
     const { family } = this.props
-    const firstParticipant = family.snapshotList.length
-      ? family.snapshotList[0].familyData.familyMembersList.find(
-          item => item.firstParticipant
-        )
-      : null
+    const firstParticipant =
+      family.snapshotList && family.snapshotList.length
+        ? family.snapshotList[0].familyData.familyMembersList.find(
+            item => item.firstParticipant
+          )
+        : null
     const birthDate = firstParticipant ? firstParticipant.birthDate : ''
-    console.log(this.props.error)
+
     return (
       <ListItem
         style={{ ...styles.listItem }}
         onPress={this.props.handleClick}
-        disabled={!family.snapshotList.length}
+        disabled={family.snapshotList && !family.snapshotList.length}
       >
         <Icon name="face" color={colors.grey} size={40} style={styles.icon} />
         <View style={styles.listItemContainer}>
           <Text style={{ ...globalStyles.p, ...styles.p }}>{family.name}</Text>
-          {family.snapshotList.length ? (
+          {family.snapshotList && family.snapshotList.length ? (
             <Text style={{ ...globalStyles.subline, ...styles.p }}>
               {`DOB: ${moment(birthDate).format('MMM, DD YYYY')}`}
             </Text>

--- a/src/components/FamiliesListItem.js
+++ b/src/components/FamiliesListItem.js
@@ -17,7 +17,9 @@ class FamiliesListItem extends Component {
             item => item.firstParticipant
           )
         : null
-    const birthDate = firstParticipant ? firstParticipant.birthDate : null
+    const birthDate = firstParticipant
+      ? firstParticipant.birthDate
+      : family.birthDate
 
     return (
       <ListItem
@@ -28,7 +30,8 @@ class FamiliesListItem extends Component {
         <Icon name="face" color={colors.grey} size={40} style={styles.icon} />
         <View style={styles.listItemContainer}>
           <Text style={{ ...globalStyles.p, ...styles.p }}>{family.name}</Text>
-          {family.snapshotList && family.snapshotList.length ? (
+          {!family.snapshotList ||
+          (family.snapshotList && family.snapshotList.length) ? (
             <Text style={{ ...globalStyles.subline, ...styles.p }}>
               {birthDate
                 ? `DOB: ${moment
@@ -57,7 +60,8 @@ class FamiliesListItem extends Component {
 FamiliesListItem.propTypes = {
   family: PropTypes.object.isRequired,
   handleClick: PropTypes.func.isRequired,
-  error: PropTypes.string
+  error: PropTypes.string,
+  birthDate: PropTypes.number
 }
 
 const styles = StyleSheet.create({

--- a/src/components/__tests__/FamiliesListItem.test.js
+++ b/src/components/__tests__/FamiliesListItem.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { shallow } from 'enzyme'
-import { TouchableOpacity, Text, View } from 'react-native'
+import { Text, View } from 'react-native'
 import Icon from 'react-native-vector-icons/MaterialIcons'
 import FamiliesListItem from '../FamiliesListItem'
 import ListItem from '../ListItem'
@@ -65,6 +65,21 @@ describe('FamiliesListItem Component', () => {
           .first()
           .props().children
       ).toEqual('Juan Perez')
+    })
+    it('renders a not sunced family', () => {
+      props = createTestProps({
+        family: {
+          name: 'San Migel'
+        }
+      })
+      wrapper = shallow(<FamiliesListItem {...props} />)
+
+      expect(
+        wrapper
+          .find(Text)
+          .first()
+          .props().children
+      ).toEqual('San Migel')
     })
   })
   describe('functionality', () => {

--- a/src/screens/Families.js
+++ b/src/screens/Families.js
@@ -54,12 +54,19 @@ export class Families extends Component {
       this.props.offline.online &&
       this.props.offline.outbox.find(item => item.type === 'LOAD_FAMILIES')
 
-    const draftFamilies = this.props.drafts.map(draft => {
-      const primaryParticipant = draft.familyData.familyMembersList[0]
-      return {
-        name: `${primaryParticipant.firstName} ${primaryParticipant.lastName}`
-      }
-    })
+    // show not synced families from drafts
+    const draftFamilies = this.props.drafts
+      .filter(draft => draft.status !== 'Synced')
+      .map(draft => {
+        const primaryParticipant = draft.familyData.familyMembersList[0]
+        return {
+          name: `${primaryParticipant.firstName} ${
+            primaryParticipant.lastName
+          }`,
+          birthDate: primaryParticipant.birthDate,
+          draft
+        }
+      })
 
     const allFamilies = [...draftFamilies, ...this.props.families]
 
@@ -97,9 +104,13 @@ export class Families extends Component {
               handleClick={() =>
                 this.props.navigation.navigate('Family', {
                   familyName: item.name,
-                  familyLifemap: item.snapshotList[0],
-                  survey: this.props.surveys.find(
-                    survey => survey.id === item.snapshotList[0].surveyId
+                  familyLifemap: item.snapshotList
+                    ? item.snapshotList[0]
+                    : item.draft,
+                  survey: this.props.surveys.find(survey =>
+                    item.snapshotList
+                      ? survey.id === item.snapshotList[0].surveyId
+                      : survey.id === item.draft.surveyId
                   )
                 })
               }
@@ -121,7 +132,8 @@ Families.propTypes = {
   env: PropTypes.oneOf(['production', 'demo', 'testing', 'development']),
   user: PropTypes.object.isRequired,
   offline: PropTypes.object,
-  t: PropTypes.func
+  t: PropTypes.func,
+  lng: PropTypes.string
 }
 
 const styles = StyleSheet.create({

--- a/src/screens/Families.js
+++ b/src/screens/Families.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import {
-  View,
   StyleSheet,
   ScrollView,
   ActivityIndicator,
@@ -25,16 +24,27 @@ export class Families extends Component {
     }
   }
   render() {
+    const { t } = this.props
+
     const familiesToSync =
       this.props.offline.online &&
       this.props.offline.outbox.find(item => item.type === 'LOAD_FAMILIES')
 
-    const filteredFamilies = this.props.families.filter(
+    const draftFamilies = this.props.drafts.map(draft => {
+      const primaryParticipant = draft.familyData.familyMembersList[0]
+      return {
+        name: `${primaryParticipant.firstName} ${primaryParticipant.lastName}`
+      }
+    })
+
+    const allFamilies = [...draftFamilies, ...this.props.families]
+
+    const filteredFamilies = allFamilies.filter(
       family =>
-        family.name.includes(this.state.search) ||
-        family.code.includes(this.state.search)
+        family.name.toLowerCase().includes(this.state.search.toLowerCase()) ||
+        (family.code && family.code.includes(this.state.search))
     )
-    const { t } = this.props
+
     return (
       <ScrollView
         style={globalStyles.background}
@@ -80,11 +90,13 @@ export class Families extends Component {
 Families.propTypes = {
   families: PropTypes.array,
   surveys: PropTypes.array,
+  drafts: PropTypes.array,
   navigation: PropTypes.object.isRequired,
   loadFamilies: PropTypes.func.isRequired,
   env: PropTypes.oneOf(['production', 'demo', 'testing', 'development']),
   user: PropTypes.object.isRequired,
-  offline: PropTypes.object
+  offline: PropTypes.object,
+  t: PropTypes.func
 }
 
 const styles = StyleSheet.create({
@@ -97,12 +109,20 @@ const styles = StyleSheet.create({
   search: { margin: 10 }
 })
 
-const mapStateToProps = ({ families, user, offline, env, surveys }) => ({
+const mapStateToProps = ({
   families,
   user,
   offline,
   env,
-  surveys
+  surveys,
+  drafts
+}) => ({
+  families,
+  user,
+  offline,
+  env,
+  surveys,
+  drafts
 })
 
 const mapDispatchToProps = {

--- a/src/screens/Family.js
+++ b/src/screens/Family.js
@@ -58,7 +58,8 @@ export class Family extends Component {
 }
 
 Family.propTypes = {
-  navigation: PropTypes.object.isRequired
+  navigation: PropTypes.object.isRequired,
+  t: PropTypes.func
 }
 
 const styles = StyleSheet.create({
@@ -74,6 +75,6 @@ const styles = StyleSheet.create({
   }
 })
 
-const mapStateToProps = ({}) => ({})
+const mapStateToProps = () => ({})
 
 export default withNamespaces()(connect(mapStateToProps)(Family))

--- a/src/screens/__tests__/Families.test.js
+++ b/src/screens/__tests__/Families.test.js
@@ -1,12 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import {
-  ScrollView,
-  View,
-  Button,
-  ActivityIndicator,
-  FlatList
-} from 'react-native'
+import { ScrollView, ActivityIndicator, FlatList } from 'react-native'
 import { Families } from '../Families'
 import SearchBar from '../../components/SearchBar'
 
@@ -31,6 +25,18 @@ const createTestProps = props => ({
       familyId: 33,
       name: 'The Jetsons',
       code: '456'
+    }
+  ],
+  drafts: [
+    {
+      familyData: {
+        familyMembersList: [
+          {
+            firstName: 'Test',
+            lastName: 'User'
+          }
+        ]
+      }
     }
   ],
   user: { token: '' },
@@ -78,8 +84,8 @@ describe('Families View', () => {
     })
   })
 
-  it('passes the correct number of families to FlatList', () => {
-    expect(wrapper.find(FlatList).props().data).toHaveLength(3)
+  it('passes the correct number of synced and non synced families to FlatList', () => {
+    expect(wrapper.find(FlatList).props().data).toHaveLength(4)
   })
 
   describe('functionality', () => {
@@ -102,11 +108,11 @@ describe('Families View', () => {
       expect(wrapper.instance().state.search).toEqual('Adams')
     })
   })
-  it('filters family when search bar value changes', () => {
+  it('filters families list when search bar value changes, search is case insensitive', () => {
     wrapper
       .find(SearchBar)
       .props()
-      .onChangeText('Adams')
+      .onChangeText('adams')
     expect(wrapper.find(FlatList).props().data).toHaveLength(1)
   })
 })

--- a/src/screens/__tests__/Families.test.js
+++ b/src/screens/__tests__/Families.test.js
@@ -3,7 +3,6 @@ import { shallow } from 'enzyme'
 import { ScrollView, ActivityIndicator, FlatList } from 'react-native'
 import { Families } from '../Families'
 import SearchBar from '../../components/SearchBar'
-import FamilyTab from '../../components/FamilyTab'
 
 const createTestProps = props => ({
   loadFamilies: jest.fn(),

--- a/src/screens/__tests__/Family.test.js
+++ b/src/screens/__tests__/Family.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { ScrollView, View } from 'react-native'
+import { ScrollView } from 'react-native'
 import { Family } from '../Family'
 import FamilyTab from '../../components/FamilyTab'
 
@@ -30,7 +30,7 @@ describe('Single Family View', () => {
       expect(wrapper.find('#lifemap')).toHaveLength(0)
     })
   })
-  describe('rendering', () => {
+  describe('functionality', () => {
     it('has the correct initial state', () => {
       expect(wrapper.instance().state.activeTab).toBe('Details')
     })


### PR DESCRIPTION
We should now show any draft family in the families list along with the remote families. Also, the search is now case insensitive.

**To Test**
1. Create a new lifemap
2. Fill in primary participant details and exit
3. Go to families screen
4. You should see the family name that is the draft you've just created at the top of the list.
5. Try searching for it in the search bar. Also try using different case than the family is written in (for example `anna` should also return results for `Anna`).
