### PR TITLE
579 revert old slider

### DIFF
--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { View, StyleSheet } from 'react-native'
+import { View, StyleSheet, ScrollView } from 'react-native'
 import SliderItem from './SliderItem'
 import colors from '../theme.json'
 import { connect } from 'react-redux'
-import Carousel from 'react-native-snap-carousel'
+import { isPortrait } from '../responsivenessHelpers'
 
 const slideColors = {
   1: 'red',
@@ -16,68 +16,86 @@ export class Slider extends Component {
   state = {
     selectedColor: colors.palegreen
   }
+  timer
+  componentDidMount() {
+    const { width } = this.props.dimensions
 
-  getSelectedAnswer = value => {
-    switch (value) {
-      case 1:
-        return 2
-      case 2:
-        return 1
-      case 3:
-        return 0
-      default:
-        return 0
+    const value = value => {
+      switch (value) {
+        case 1:
+          return 2
+        case 2:
+          return 1
+        case 3:
+          return 0
+        default:
+          return 0
+      }
+    }
+
+    if (value(this.props.value)) {
+      this.timer = setTimeout(() => {
+        if (this.scrollView) {
+          this.scrollView.scrollTo({
+            x: (width - (1 / 10) * width) * value(this.props.value),
+            animated: true
+          })
+        }
+      }, 1)
     }
   }
 
-  renderSlide = ({ item, index }) => {
-    return (
-      <View
-        key={index}
-        style={[
-          styles.slideWrapper,
-          { backgroundColor: colors[slideColors[item.value]] }
-        ]}
-      >
-        <SliderItem
-          slide={item}
-          onPress={() => {
-            this.props.selectAnswer(item.value)
-            this.setState({
-              selectedColor: colors[slideColors[item.value]]
-            })
-          }}
-          value={this.props.value}
-          bodyHeight={this.props.bodyHeight}
-          dimensions={this.props.dimensions}
-          portrait={this.props.portrait}
-          tablet={this.props.tablet}
-        />
-      </View>
-    )
+  componentWillUnmount() {
+    clearTimeout(this.timer)
   }
 
   render() {
     const { width } = this.props.dimensions
-    const activeSlide = this.props.value
-      ? this.getSelectedAnswer(this.props.value)
-      : 0
     return (
       <View>
-        <Carousel
-          ref={c => this._carousel = c}
-          data={this.props.slides}
-          renderItem={this.renderSlide}
-          sliderWidth={width}
-          containerCustomStyle={{ overflow: 'visible' }}
-          itemWidth={this.props.portrait ? width - 60 : width / 2 + 50}
-          loop={true}
-          inactiveSlideOpacity={1}
-          activeSlideAlignment={'center'}
-          loopClonesPerSide={10}
-          firstItem={activeSlide}
-          activeSlideOffset={50}
-        />
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={{
+            width: isPortrait(this.props.dimensions) ? '280%' : '90%',
+            flexGrow: 1,
+            flexDirection: 'row',
+            flexWrap: 'wrap',
+            justifyContent: 'space-around',
+            padding: '2%'
+          }}
+          ref={ref => {
+            this.scrollView = ref
+          }}
+          snapToAlignment="center"
+          snapToInterval={width - (1 / 10) * width}
+        >
+          {this.props.slides.map((slide, i) => (
+            <View
+              key={i}
+              style={{
+                width: '32.2%',
+                backgroundColor: colors[slideColors[slide.value]],
+                borderRadius: 3
+              }}
+            >
+              <SliderItem
+                slide={slide}
+                onPress={() => {
+                  this.props.selectAnswer(slide.value)
+                  this.setState({
+                    selectedColor: colors[slideColors[slide.value]]
+                  })
+                }}
+                value={this.props.value}
+                bodyHeight={this.props.bodyHeight}
+                dimensions={this.props.dimensions}
+                portrait={this.props.portrait}
+                tablet={this.props.tablet}
+              />
+            </View>
+          ))}
+        </ScrollView>
       </View>
     )
   }
@@ -92,13 +110,6 @@ Slider.propTypes = {
   tablet: PropTypes.bool,
   portrait: PropTypes.bool
 }
-
-const styles = StyleSheet.create({
-  slideWrapper: {
-    borderRadius: 3,
-    paddingTop: 10
-  }
-})
 
 const mapStateToProps = ({ dimensions }) => ({
   dimensions

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -61,8 +61,7 @@ export class Slider extends Component {
             flexGrow: 1,
             flexDirection: 'row',
             flexWrap: 'wrap',
-            justifyContent: 'space-around',
-            padding: '2%'
+            justifyContent: 'space-around'
           }}
           ref={ref => {
             this.scrollView = ref
@@ -74,7 +73,7 @@ export class Slider extends Component {
             <View
               key={i}
               style={{
-                width: '32.2%',
+                width: '32%',
                 backgroundColor: colors[slideColors[slide.value]],
                 borderRadius: 3
               }}

--- a/src/components/SliderItem.js
+++ b/src/components/SliderItem.js
@@ -138,7 +138,8 @@ const styles = StyleSheet.create({
   },
   image: {
     width: '100%',
-    borderRadius: 3
+    borderRadius: 3,
+    marginTop: 10
   },
   iconBig: {
     borderRadius: 50,

--- a/src/components/SliderItem.js
+++ b/src/components/SliderItem.js
@@ -137,8 +137,8 @@ const styles = StyleSheet.create({
     alignItems: 'center'
   },
   image: {
-    width: '100%'
-    // marginTop: 10
+    width: '100%',
+    borderRadius: 3
   },
   iconBig: {
     borderRadius: 50,

--- a/src/components/__tests__/Slider.test.js
+++ b/src/components/__tests__/Slider.test.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { Slider } from '../Slider'
-import Carousel from 'react-native-snap-carousel'
+import { ScrollView } from 'react-native'
+import  SliderItem  from '../SliderItem'
 
 const createTestProps = props => ({
   slides: [
@@ -40,7 +41,11 @@ describe('Slider Component', () => {
   })
   describe('rendering', () => {
     it('renders ScrollView', () => {
-      expect(wrapper.find(Carousel)).toHaveLength(1)
+      expect(wrapper.find(ScrollView)).toHaveLength(1)
+    })
+
+     it('renders SliderItem', () => {
+      expect(wrapper.find(SliderItem)).toHaveLength(3)
     })
   })
 })

--- a/src/screens/lifemap/Question.js
+++ b/src/screens/lifemap/Question.js
@@ -184,8 +184,10 @@ export class Question extends Component {
 const styles = StyleSheet.create({
   skip: {
     alignItems: 'flex-end',
+    justifyContent: 'center',
     marginRight: 30,
-    marginTop: 15
+    marginTop: 0,
+    height: 60
   },
   link: {
     color: colors.palegreen


### PR DESCRIPTION
Removed the infinite scrolling on the indicators images

1. Go inside survey 
2. Go to  Stoplight Questions slider 
3. You should see only three slides for each question 