### PR TITLE
Progress bar methodology update

### DIFF
--- a/src/navigation/LifemapScreens.js
+++ b/src/navigation/LifemapScreens.js
@@ -127,7 +127,7 @@ export default {
   Overview: {
     screen: OverviewView,
     navigationOptions: ({ navigation }) => ({
-      ...generateNavStyles({ navigation }),
+      ...generateNavStyles({ navigation, shadowHeader: false }),
       ...addCloseIcon(navigation),
       headerTitle: (
         <Title title="views.yourLifeMap" style={{ marginLeft: 20 }} />

--- a/src/screens/Loading.js
+++ b/src/screens/Loading.js
@@ -83,7 +83,7 @@ export class Loading extends Component {
                 name: 'GECO',
                 styleURL: MapboxGL.StyleURL.Street,
                 minZoom: 10,
-                maxZoom: 15,
+                maxZoom: 13,
                 bounds: [[-71.0187, -33.687], [-70.3036, -33.1287]]
               },
               this.onMapDownloadProgress,

--- a/src/screens/__mocks__/fake-socio-economic-data.json
+++ b/src/screens/__mocks__/fake-socio-economic-data.json
@@ -1,4 +1,6 @@
 {
+  "surveyStoplightQuestions": [],
+  "surveyEconomicQuestions": [],
   "surveyEconomicQuestions": [
     {
       "questionText": "Is there any member with disabilities in your household? Please indicate the disability type",

--- a/src/screens/__tests__/BeginLifemap.test.js
+++ b/src/screens/__tests__/BeginLifemap.test.js
@@ -11,6 +11,7 @@ const createTestProps = props => ({
   nav: {
     draftId: 4,
     survey: {
+      surveyEconomicQuestions: [],
       id: 2,
       title: 'Other survey',
       surveyStoplightQuestions: [{ a: 'a' }, { b: 'b' }, { c: 'c' }]

--- a/src/screens/__tests__/FamilyMembersNames.test.js
+++ b/src/screens/__tests__/FamilyMembersNames.test.js
@@ -10,6 +10,8 @@ const createTestProps = props => ({
   t: value => value,
   nav: {
     survey: {
+      surveyStoplightQuestions: [],
+      surveyEconomicQuestions: [],
       surveyConfig: {
         gender: [
           {

--- a/src/screens/__tests__/FamilyParticipant.test.js
+++ b/src/screens/__tests__/FamilyParticipant.test.js
@@ -18,6 +18,7 @@ const createTestProps = props => ({
       title: 'Dev Demo',
       survey_version_id: 2,
       surveyStoplightQuestions: [],
+      surveyEconomicQuestions: [],
       surveyConfig: {
         surveyLocation: { country: 'BG' },
         gender: [

--- a/src/screens/__tests__/Final.test.js
+++ b/src/screens/__tests__/Final.test.js
@@ -10,7 +10,7 @@ const createTestProps = props => ({
   t: value => value,
   nav: {
     draftId: 4,
-    survey: { surveyStoplightQuestions: [] }
+    survey: { surveyStoplightQuestions: [], surveyEconomicQuestions: [] }
   },
   user: { token: 'token' },
   env: 'env',

--- a/src/screens/__tests__/Overview.test.js
+++ b/src/screens/__tests__/Overview.test.js
@@ -16,6 +16,7 @@ const createTestProps = props => ({
       id: 2,
       title: 'Other survey',
       minimumPriorities: 5,
+      surveyEconomicQuestions: [],
       surveyStoplightQuestions: [
         { phoneNumber: 'phoneNumber' },
         { education: 'education' },

--- a/src/screens/__tests__/Question.test.js
+++ b/src/screens/__tests__/Question.test.js
@@ -18,7 +18,8 @@ const createTestProps = props => ({
           required: false,
           dimension: 'Dimension'
         }
-      ]
+      ],
+      surveyEconomicQuestions: []
     }
   },
   navigation: {
@@ -31,7 +32,7 @@ const createTestProps = props => ({
         return 0
       }
     }),
-    state: { params: { headerHeight: 100  } }
+    state: { params: { headerHeight: 100 } }
   },
   dimensions: { height: 100 },
   addSurveyData: jest.fn(),

--- a/src/screens/__tests__/Skipped.test.js
+++ b/src/screens/__tests__/Skipped.test.js
@@ -12,6 +12,7 @@ const createTestProps = props => ({
     survey: {
       id: 2,
       title: 'Other survey',
+      surveyEconomicQuestions: [],
       surveyStoplightQuestions: [
         { phoneNumber: 'phoneNumber' },
         { education: 'education' },

--- a/src/screens/lifemap/BeginLifemap.js
+++ b/src/screens/lifemap/BeginLifemap.js
@@ -8,7 +8,7 @@ import globalStyles from '../../globalStyles'
 import RoundImage from '../../components/RoundImage'
 import StickyFooter from '../../components/StickyFooter'
 import { addDraftProgress } from '../../redux/actions'
-import { getDraft } from './helpers'
+import { getDraft, getTotalEconomicScreens } from './helpers'
 
 export class BeginLifemap extends Component {
   numberOfQuestions = this.props.nav.survey.surveyStoplightQuestions.length
@@ -24,24 +24,12 @@ export class BeginLifemap extends Component {
   }
 
   onPressBack = () => {
-    const draft = getDraft()
-
-    this.props.addDraftProgress(this.props.nav.draftId, {
-      current: draft.progress.current - 1
-    })
-
     this.props.navigation.replace('SocioEconomicQuestion', {
       fromBeginLifemap: true
     })
   }
 
   handleClick = () => {
-    const draft = getDraft()
-
-    this.props.addDraftProgress(this.props.nav.draftId, {
-      current: draft.progress.current + 1
-    })
-
     this.props.navigation.navigate('Question', {
       step: 0
     })
@@ -54,7 +42,13 @@ export class BeginLifemap extends Component {
       <StickyFooter
         handleClick={this.handleClick}
         continueLabel={t('general.continue')}
-        progress={draft ? draft.progress.current / draft.progress.total : 0}
+        progress={
+          draft
+            ? ((draft.familyData.countFamilyMembers > 1 ? 4 : 3) +
+                getTotalEconomicScreens(this.props.nav.survey)) /
+              draft.progress.total
+            : 0
+        }
       >
         <View
           style={{

--- a/src/screens/lifemap/FamilyMembersNames.js
+++ b/src/screens/lifemap/FamilyMembersNames.js
@@ -15,7 +15,7 @@ import Decoration from '../../components/decoration/Decoration'
 import globalStyles from '../../globalStyles'
 import Select from '../../components/Select'
 import DateInput from '../../components/DateInput'
-import { getDraft } from './helpers'
+import { getDraft, getTotalScreens } from './helpers'
 
 export class FamilyMembersNames extends Component {
   gender = this.props.nav.survey.surveyConfig.gender
@@ -24,7 +24,8 @@ export class FamilyMembersNames extends Component {
 
   componentDidMount() {
     this.props.addDraftProgress(this.props.nav.draftId, {
-      screen: 'FamilyMembersNames'
+      screen: 'FamilyMembersNames',
+      total: getTotalScreens(this.props.nav.survey)
     })
 
     this.props.navigation.setParams({
@@ -33,13 +34,6 @@ export class FamilyMembersNames extends Component {
   }
 
   onPressBack = () => {
-    const draft = getDraft()
-
-    this.props.addDraftProgress(this.props.nav.draftId, {
-      current: draft.progress.current - 1,
-      total: draft.progress.total - 1
-    })
-
     this.props.navigation.navigate('FamilyParticipant', {
       draftId: this.props.nav.draftId
     })
@@ -61,17 +55,11 @@ export class FamilyMembersNames extends Component {
   }
 
   handleClick = () => {
-    const draft = getDraft()
-
     if (this.state.errorsDetected.length) {
       this.setState({
         showErrors: true
       })
     } else {
-      this.props.addDraftProgress(this.props.nav.draftId, {
-        current: draft.progress.current + 1
-      })
-
       this.props.navigation.navigate('Location')
     }
   }
@@ -134,7 +122,7 @@ export class FamilyMembersNames extends Component {
       <StickyFooter
         handleClick={() => this.handleClick(draft)}
         continueLabel={t('general.continue')}
-        progress={draft ? draft.progress.current / draft.progress.total : 0}
+        progress={draft ? 2 / draft.progress.total : 0}
       >
         <Decoration variation="familyMemberNamesHeader">
           <View style={styles.circleContainer}>

--- a/src/screens/lifemap/FamilyParticipant.js
+++ b/src/screens/lifemap/FamilyParticipant.js
@@ -20,6 +20,7 @@ import DateInput from '../../components/DateInput'
 import Decoration from '../../components/decoration/Decoration'
 import colors from '../../theme.json'
 import globalStyles from '../../globalStyles'
+import { getTotalScreens } from './helpers'
 
 export class FamilyParticipant extends Component {
   //Get draft id from Redux store if it exists else create new draft id
@@ -44,9 +45,10 @@ export class FamilyParticipant extends Component {
   }
 
   createDraft() {
+    const { survey } = this.props.nav
     this.props.createDraft({
-      surveyId: this.props.nav.survey.id,
-      surveyVersionId: this.props.nav.survey['surveyVersionId'],
+      surveyId: survey.id,
+      surveyVersionId: survey['surveyVersionId'],
       created: Date.now(),
       draftId: this.draftId,
       economicSurveyDataList: [],
@@ -55,8 +57,7 @@ export class FamilyParticipant extends Component {
       achievements: [],
       progress: {
         screen: 'FamilyParticipant',
-        current: 1,
-        total: 5 + this.props.nav.survey.surveyStoplightQuestions.length
+        total: getTotalScreens(survey)
       },
       familyData: {
         familyMembersList: [
@@ -83,8 +84,7 @@ export class FamilyParticipant extends Component {
     if (!this.props.nav.readonly && this.props.nav.draftId) {
       this.props.addDraftProgress(this.draftId, {
         screen: 'FamilyParticipant',
-        current: 1,
-        total: 5 + this.props.nav.survey.surveyStoplightQuestions.length
+        total: getTotalScreens(this.props.nav.survey)
       })
     }
   }
@@ -104,18 +104,9 @@ export class FamilyParticipant extends Component {
 
       if (this.getFamilyCount(draft) > 1) {
         // if multiple family members navigate to members screens
-        this.props.addDraftProgress(this.draftId, {
-          current: draft.progress.current + 1,
-          total: draft.progress.total + 2
-        })
-
         this.props.navigation.navigate('FamilyMembersNames')
       } else {
         // if only one family member, navigate directly to location
-        this.props.addDraftProgress(draft.draftId, {
-          current: draft.progress.current + 1
-        })
-
         this.props.navigation.navigate('Location')
       }
     }
@@ -224,9 +215,7 @@ export class FamilyParticipant extends Component {
         handleClick={this.handleClick}
         continueLabel={t('general.continue')}
         readonly={readonly}
-        progress={
-          !readonly && draft ? draft.progress.current / draft.progress.total : 0
-        }
+        progress={!readonly && draft ? 1 / draft.progress.total : 0}
       >
         <Decoration variation="primaryParticipant">
           <Icon name="face" color={colors.grey} size={61} style={styles.icon} />

--- a/src/screens/lifemap/Location.js
+++ b/src/screens/lifemap/Location.js
@@ -9,7 +9,9 @@ import {
   TouchableHighlight,
   NetInfo
 } from 'react-native'
+/* eslint-disable import/named */
 import { GooglePlacesAutocomplete } from 'react-native-google-places-autocomplete'
+/* eslint-enable import/named */
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { withNamespaces } from 'react-i18next'

--- a/src/screens/lifemap/Location.js
+++ b/src/screens/lifemap/Location.js
@@ -24,7 +24,7 @@ import marker from '../../../assets/images/marker.png'
 import center from '../../../assets/images/centerMap.png'
 import happy from '../../../assets/images/happy.png'
 import sad from '../../../assets/images/sad.png'
-import { getDraft } from './helpers'
+import { getDraft, getTotalScreens } from './helpers'
 
 export class Location extends Component {
   state = {
@@ -212,6 +212,7 @@ export class Location extends Component {
   }
 
   componentDidMount() {
+    const { survey } = this.props.nav
     // set search location keyboard events
     this.keyboardDidShowListener = Keyboard.addListener(
       'keyboardDidShow',
@@ -226,10 +227,7 @@ export class Location extends Component {
 
     // the there is no save country in the draft, set it to the survey one
     if (!this.getFieldValue(draft, 'country')) {
-      this.addSurveyData(
-        this.props.nav.survey.surveyConfig.surveyLocation.country,
-        'country'
-      )
+      this.addSurveyData(survey.surveyConfig.surveyLocation.country, 'country')
     }
 
     // monitor for connection changes
@@ -272,7 +270,8 @@ export class Location extends Component {
     })
 
     this.props.addDraftProgress(draft.draftId, {
-      screen: 'Location'
+      screen: 'Location',
+      total: getTotalScreens(survey)
     })
 
     if (!this.props.nav.readonly) {
@@ -295,10 +294,6 @@ export class Location extends Component {
   onPressBack = () => {
     const { draftId } = this.props.nav
     const draft = getDraft()
-
-    this.props.addDraftProgress(draftId, {
-      current: draft.progress.current - 1
-    })
 
     if (draft.familyData.familyMembersList.length > 1) {
       this.props.navigation.navigate('FamilyMembersNames')
@@ -323,12 +318,6 @@ export class Location extends Component {
         showErrors: true
       })
     } else {
-      const draft = this.props.navigation.getParam('family') || getDraft()
-
-      this.props.addDraftProgress(this.props.nav.draftId, {
-        current: draft.progress.current + 1
-      })
-
       this.props.navigation.replace('SocioEconomicQuestion')
     }
   }
@@ -372,7 +361,8 @@ export class Location extends Component {
           continueLabel={t('general.continue')}
           progress={
             !readonly && draft
-              ? draft.progress.current / draft.progress.total
+              ? (draft.familyData.countFamilyMembers > 1 ? 3 : 2) /
+                draft.progress.total
               : 0
           }
           fullHeight

--- a/src/screens/lifemap/Overview.js
+++ b/src/screens/lifemap/Overview.js
@@ -59,9 +59,7 @@ export class Overview extends Component {
       const skippedQuestions = draft.indicatorSurveyDataList.filter(
         question => question.value === 0
       )
-      this.props.addDraftProgress(this.props.nav.draftId, {
-        current: draft.progress.current - 1
-      })
+
       // If there are no skipped questions
       if (skippedQuestions.length > 0) {
         this.props.navigation.navigate('Skipped')
@@ -134,9 +132,8 @@ export class Overview extends Component {
     const { survey } = this.props.nav
     const { t } = this.props
     const { filterModalIsOpen, selectedFilter, filterLabel } = this.state
-    const data = this.props.familyLifemap
-      ? this.props.familyLifemap
-      : getDraft()
+
+    const data = this.props.familyLifemap || getDraft()
 
     const mandatoryPrioritiesCount = this.getMandatoryPrioritiesCount(data)
 
@@ -172,6 +169,11 @@ export class Overview extends Component {
         tipTitle={t('views.lifemap.toComplete')}
         onTipClose={this.onTipClose}
         tipDescription={getTipDescription()}
+        progress={
+          !this.resumeDraft && !this.props.familyLifemap
+            ? (data.progress.total - 1) / data.progress.total
+            : 0
+        }
       >
         <View style={[globalStyles.background, styles.contentContainer]}>
           <View style={styles.indicatorsContainer}>

--- a/src/screens/lifemap/Question.js
+++ b/src/screens/lifemap/Question.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { withNamespaces } from 'react-i18next'
 import { isPortrait, isTablet } from '../../responsivenessHelpers'
-import { getDraft } from './helpers'
+import { getDraft, getTotalEconomicScreens } from './helpers'
 
 import {
   addSurveyData,
@@ -84,17 +84,10 @@ export class Question extends Component {
       this.step + 1 < this.indicators.length &&
       !this.props.navigation.getParam('skipped')
     ) {
-      this.props.addDraftProgress(draftId, {
-        current: draft.progress.current + 1
-      })
       return this.props.navigation.replace('Question', {
         step: this.step + 1
       })
     } else if (this.step + 1 >= this.indicators.length && answer === 0) {
-      this.props.addDraftProgress(draftId, {
-        current: draft.progress.current + 1,
-        total: draft.progress.total + 1
-      })
       return this.props.navigation.navigate('Skipped')
     } else if (
       (this.props.navigation.getParam('skipped') &&
@@ -102,27 +95,15 @@ export class Question extends Component {
         answer !== 0) ||
       skippedQuestions.length === 0
     ) {
-      this.props.addDraftProgress(draftId, {
-        current: draft.progress.current + 1
-      })
       return this.props.navigation.navigate('Overview', {
         resumeDraft: false
       })
     } else {
-      this.props.addDraftProgress(draftId, {
-        current: draft.progress.current + 1,
-        total: draft.progress.total + 1
-      })
       return this.props.navigation.replace('Skipped')
     }
   }
 
   onPressBack = () => {
-    const draft = getDraft()
-    this.props.addDraftProgress(this.props.nav.draftId, {
-      current: draft.progress.current - 1
-    })
-
     if (this.step > 0) {
       this.props.navigation.replace('Question', {
         step: this.step - 1
@@ -139,15 +120,27 @@ export class Question extends Component {
     const portrait = !!dimensions && isPortrait(dimensions)
     const tablet = !!dimensions && isTablet(dimensions)
     const bodyHeight = dimensions.height - headerHeight - paddingOfStickyFooter
-    
+
     return (
       <StickyFooter
         handleClick={this.handleClick}
         readonly
-        progress={draft ? draft.progress.current / draft.progress.total : 0}
+        progress={
+          draft
+            ? ((draft.familyData.countFamilyMembers > 1 ? 5 : 4) +
+                getTotalEconomicScreens(this.props.nav.survey) +
+                this.step) /
+              draft.progress.total
+            : 0
+        }
         currentScreen="Question"
       >
-        <View style={[{ height: bodyHeight }, tablet && portrait ? {marginTop: 30} : {}]}>
+        <View
+          style={[
+            { height: bodyHeight },
+            tablet && portrait ? { marginTop: 30 } : {}
+          ]}
+        >
           <SliderComponent
             slides={this.slides}
             value={this.getFieldValue(draft, this.indicator.codeName)}
@@ -156,7 +149,16 @@ export class Question extends Component {
             tablet={tablet}
             portrait={portrait}
           />
-          <View style={[styles.skip, !tablet && !portrait ? { height: 40 } : tablet && portrait ? { height: 120 } : {height: 60} ]}>
+          <View
+            style={[
+              styles.skip,
+              !tablet && !portrait
+                ? { height: 40 }
+                : tablet && portrait
+                ? { height: 120 }
+                : { height: 60 }
+            ]}
+          >
             {this.indicator.required ? (
               <Text>{t('views.lifemap.responseRequired')}</Text>
             ) : (
@@ -177,7 +179,7 @@ const styles = StyleSheet.create({
   skip: {
     alignItems: 'flex-end',
     justifyContent: 'center',
-    marginRight: 30,
+    marginRight: 30
     // marginTop: 0
   },
   link: {

--- a/src/screens/lifemap/Skipped.js
+++ b/src/screens/lifemap/Skipped.js
@@ -6,7 +6,7 @@ import { withNamespaces } from 'react-i18next'
 import { addDraftProgress } from '../../redux/actions'
 import StickyFooter from '../../components/StickyFooter'
 import SkippedListItem from '../../components/SkippedListItem'
-import { getDraft } from './helpers'
+import { getDraft, getTotalScreens } from './helpers'
 
 export class Skipped extends Component {
   indicatorsArray = this.props.nav.survey.surveyStoplightQuestions.map(
@@ -16,7 +16,8 @@ export class Skipped extends Component {
 
   componentDidMount() {
     this.props.addDraftProgress(this.props.nav.draftId, {
-      screen: 'Skipped'
+      screen: 'Skipped',
+      total: getTotalScreens(this.props.nav.survey)
     })
     this.props.navigation.setParams({
       onPressBack: this.onPressBack
@@ -24,11 +25,6 @@ export class Skipped extends Component {
   }
 
   onPressBack = () => {
-    const draft = getDraft()
-    this.props.addDraftProgress(this.props.nav.draftId, {
-      current: draft.progress.total - 2
-    })
-
     this.props.navigation.navigate('Question', {
       step: this.props.nav.survey.surveyStoplightQuestions.length - 1
     })
@@ -56,6 +52,7 @@ export class Skipped extends Component {
     const skippedQuestions = draft.indicatorSurveyDataList.filter(
       question => question.value === 0
     )
+
     return (
       <StickyFooter
         handleClick={this.handleClick}
@@ -64,7 +61,7 @@ export class Skipped extends Component {
         tipTitle={t('views.lifemap.youSkipped')}
         tipDescription={t('views.lifemap.whyNotTryAgain')}
         onTipClose={this.onTipClose}
-        progress={draft ? (draft.progress.total - 1) / draft.progress.total : 0}
+        progress={draft ? (draft.progress.total - 2) / draft.progress.total : 0}
       >
         <Image
           style={styles.image}

--- a/src/screens/lifemap/SocioEconomicQuestion.js
+++ b/src/screens/lifemap/SocioEconomicQuestion.js
@@ -12,7 +12,7 @@ import {
   addDraftProgress
 } from '../../redux/actions'
 import colors from '../../theme.json'
-import { getDraft } from './helpers'
+import { getDraft, getTotalScreens } from './helpers'
 
 export class SocioEconomicQuestion extends Component {
   static navigationOptions = ({ navigation }) => {
@@ -118,10 +118,10 @@ export class SocioEconomicQuestion extends Component {
 
   componentDidMount() {
     const { readonly } = this.props.nav
+
     if (!readonly) {
       this.props.addDraftProgress(this.props.nav.draftId, {
-        screen: 'SocioEconomicQuestion',
-        socioEconomics: this.props.navigation.getParam('socioEconomics')
+        screen: 'SocioEconomicQuestion'
       })
 
       if (!readonly) {
@@ -133,12 +133,7 @@ export class SocioEconomicQuestion extends Component {
   }
 
   onPressBack = () => {
-    const draft = getDraft()
     const socioEconomics = this.props.navigation.getParam('socioEconomics')
-
-    this.props.addDraftProgress(this.props.nav.draftId, {
-      current: draft.progress.current - 1
-    })
 
     socioEconomics.currentScreen === 1
       ? this.props.navigation.navigate('Location')
@@ -208,18 +203,12 @@ export class SocioEconomicQuestion extends Component {
     })
   }
   submitForm = () => {
-    const draft = getDraft()
-
     if (this.errorsDetected.length) {
       this.setState({
         showErrors: true
       })
     } else {
       const socioEconomics = this.props.navigation.getParam('socioEconomics')
-
-      this.props.addDraftProgress(this.props.nav.draftId, {
-        current: draft.progress.current + 1
-      })
 
       socioEconomics.currentScreen === socioEconomics.totalScreens
         ? this.props.navigation.navigate('BeginLifemap')
@@ -300,7 +289,11 @@ export class SocioEconomicQuestion extends Component {
         continueLabel={t('general.continue')}
         readonly={readonly}
         progress={
-          !readonly && draft ? draft.progress.current / draft.progress.total : 0
+          !readonly && draft
+            ? ((draft.familyData.countFamilyMembers > 1 ? 3 : 2) +
+                (socioEconomics ? socioEconomics.currentScreen : 1)) /
+              draft.progress.total
+            : 0
         }
       >
         {/* questions for entire family */}

--- a/src/screens/lifemap/helpers.js
+++ b/src/screens/lifemap/helpers.js
@@ -6,3 +6,34 @@ export const getDraft = () =>
     .getState()
     .drafts.find(draft => draft.draftId === store.getState().nav.draftId) ||
   draftMock
+
+const getTotalEconomicScreens = survey => {
+  let currentDimension = ''
+  let totalScreens = 0
+
+  survey.surveyEconomicQuestions.forEach(question => {
+    // if the dimention of the questions change, change the page
+    if (question.topic !== currentDimension) {
+      currentDimension = question.topic
+      totalScreens += 1
+    }
+  })
+
+  return totalScreens
+}
+
+export const getTotalScreens = survey => {
+  const draft = getDraft()
+
+  // there are 5 screens each snapshot always has:
+  // participant, location, begin lifemap, overview and final
+  return (
+    5 +
+    survey.surveyStoplightQuestions.length +
+    getTotalEconomicScreens(survey) +
+    (draft && draft.familyData.countFamilyMembers > 1 ? 1 : 0) +
+    (draft && draft.indicatorSurveyDataList.filter(item => !item.value).length
+      ? 1
+      : 0)
+  )
+}

--- a/src/screens/lifemap/helpers.js
+++ b/src/screens/lifemap/helpers.js
@@ -7,7 +7,7 @@ export const getDraft = () =>
     .drafts.find(draft => draft.draftId === store.getState().nav.draftId) ||
   draftMock
 
-const getTotalEconomicScreens = survey => {
+export const getTotalEconomicScreens = survey => {
   let currentDimension = ''
   let totalScreens = 0
 


### PR DESCRIPTION
The progress bar used to update the draft progress on user navigation. This lead to some unexpected result when the user is navigation to a page from resume draft and skipped questions. Now each page knows where it is in the total amount of screens.

**To Test**
1. Open a survey and go trough it whole. Check if the progress bar moves forward each time without going over it's right side.
2. Do the same survey with family members count more than 1. The progress bar should account for the extra screen.
3. Try going forward to socio economic screens, then backward to participant, change family count to 1 and the go forward again. Each time the progress bar should move in the appropriate direction.
4. In the indicators section, skip a question. Then in the skipped questions screen, try to answer that question. The progress bar should show the position of the question, but upon answering it should go back to skipped screen.
5. Repeat the same steps with another survey.

**Related issues:**
- Fix #568 
- Fix #495 
- Fix #308
