### PR TITLE
503 extra white space

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1436,7 +1436,7 @@
         },
         "uuid": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
           "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
         },
         "xcode": {
@@ -3644,7 +3644,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
@@ -4258,7 +4258,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "requires": {
         "chardet": "^0.4.0",
@@ -8732,7 +8732,7 @@
     },
     "lodash.isempty": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
       "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
     },
     "lodash.isequal": {
@@ -9987,7 +9987,7 @@
         },
         "node-fetch": {
           "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
           "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
           "requires": {
             "encoding": "^0.1.11",
@@ -9996,7 +9996,7 @@
         },
         "opn": {
           "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+          "resolved": "http://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
           "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
           "requires": {
             "object-assign": "^4.0.1",
@@ -10790,7 +10790,7 @@
     },
     "react-native-elements": {
       "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/react-native-elements/-/react-native-elements-0.19.1.tgz",
+      "resolved": "http://registry.npmjs.org/react-native-elements/-/react-native-elements-0.19.1.tgz",
       "integrity": "sha1-+Stp2GShUCFdAfgf48UqnK2oPkU=",
       "requires": {
         "lodash.isempty": "^4.4.0",
@@ -10912,7 +10912,7 @@
     },
     "react-native-tab-view": {
       "version": "0.0.77",
-      "resolved": "https://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-0.0.77.tgz",
+      "resolved": "http://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-0.0.77.tgz",
       "integrity": "sha512-9vjD4Ly1Zlum1Y4g23ODpi/F3gYIUIsKWrsZO/Oh5cuX1eiB1DRVn11nY1z+j/hsQfhfyW6nDlmySyDvYQvYCA==",
       "requires": {
         "prop-types": "^15.6.0"

--- a/src/components/SliderItem.js
+++ b/src/components/SliderItem.js
@@ -42,7 +42,7 @@ export default class SliderItem extends Component {
         : bodyHeight - 100
     const imageHeight = !tablet && !portrait ? bodyHeight / 3 : bodyHeight / 2
     const textAreaHeight = slideHeight - imageHeight // - 30 is margin top on image + icon
-
+    console.log(this.state.textContentHeight)
     return (
       <TouchableHighlight
         activeOpacity={1}
@@ -92,7 +92,7 @@ export default class SliderItem extends Component {
             <ScrollView
               contentContainerStyle={{
                 flexGrow: 1,
-                height: this.textContentHeight,
+                height: this.state.textContentHeight,
                 paddingBottom: 50
               }}
             >

--- a/src/components/SliderItem.js
+++ b/src/components/SliderItem.js
@@ -42,7 +42,6 @@ export default class SliderItem extends Component {
         : bodyHeight - 100
     const imageHeight = !tablet && !portrait ? bodyHeight / 3 : bodyHeight / 2
     const textAreaHeight = slideHeight - imageHeight // - 30 is margin top on image + icon
-    console.log(this.state.textContentHeight)
     return (
       <TouchableHighlight
         activeOpacity={1}

--- a/src/navigation/DrawerContent.js
+++ b/src/navigation/DrawerContent.js
@@ -20,7 +20,7 @@ import { switchLanguage, logout, updateNav } from '../redux/actions'
 import LogoutPopup from './LogoutPopup'
 import dashboardIcon from '../../assets/images/icon_dashboard.png'
 import familyNavIcon from '../../assets/images/icon_family_nav.png'
-import { isPortrait } from '../responsivenessHelpers'
+import { isPortrait, isTablet } from '../responsivenessHelpers'
 
 // Component that renders the drawer menu content. DrawerItems are the links to
 // the given views.
@@ -105,6 +105,7 @@ export class DrawerContent extends Component {
       navigation.navigate(screen)
     }
   }
+
   onLayout = e => {
     this.setState({
       drawerContentWidth: e.nativeEvent.layout.width
@@ -124,12 +125,13 @@ export class DrawerContent extends Component {
     ).length
     const { state } = navigation
     const currentStack = state.routes[state.index]
-    const portrait = !!dimensions && isPortrait(dimensions)
-    
+    const landscape = !!dimensions && !isPortrait(dimensions)
+    const phone = !!dimensions && !isTablet(dimensions)
+
     return (
       <ScrollView
         style={{ width: drawerContentWidth }}
-        contentContainerStyle={[!portrait ? {} : styles.container ]}
+        contentContainerStyle={[landscape && phone ? {} : styles.container]}
         onLayout={this.onLayout}
       >
         <View>
@@ -176,8 +178,7 @@ export class DrawerContent extends Component {
         <View style={styles.itemsContainer}>
           <ScrollView
             contentContainerStyle={{
-              flexGrow: 1,
-              height: 250,
+              flexGrow: 1
             }}
           >
             <View>
@@ -284,7 +285,7 @@ DrawerContent.propTypes = {
   user: PropTypes.object.isRequired,
   drafts: PropTypes.array.isRequired,
   env: PropTypes.oneOf(['production', 'demo', 'testing', 'development']),
-  dimensions: PropTypes.object.isRequired,
+  dimensions: PropTypes.object.isRequired
 }
 
 const mapStateToProps = ({ env, user, drafts, nav, dimensions }) => ({

--- a/src/navigation/DrawerContent.js
+++ b/src/navigation/DrawerContent.js
@@ -112,7 +112,7 @@ export class DrawerContent extends Component {
 
   render() {
     const { lng, user, navigation } = this.props
-    const { checkboxesVisible, showErrors, logingOut } = this.state
+    const { checkboxesVisible, showErrors, logingOut, drawerContentWidth } = this.state
     const unsyncedDrafts = this.props.drafts.filter(
       draft => draft.status !== 'Synced'
     ).length
@@ -121,13 +121,13 @@ export class DrawerContent extends Component {
 
     return (
       <ScrollView
-        style={{ width: this.state.drawerContentWidth }}
+        style={{ width: drawerContentWidth }}
         contentContainerStyle={styles.container}
         onLayout={this.onLayout}
       >
         <View>
           <Image
-            style={{ height: 172, width: this.state.drawerContentWidth }}
+            style={{ height: 172, width: drawerContentWidth }}
             source={require('../../assets/images/navigation_image.png')}
           />
           {/* Language Switcher */}

--- a/src/navigation/DrawerContent.js
+++ b/src/navigation/DrawerContent.js
@@ -29,7 +29,8 @@ export class DrawerContent extends Component {
     ckeckedBoxes: 0,
     showErrors: false,
     logingOut: false,
-    activeTab: 'Dashboard'
+    activeTab: 'Dashboard',
+    drawerContentWidth: 320
   }
 
   changeLanguage = lng => {
@@ -103,6 +104,12 @@ export class DrawerContent extends Component {
       navigation.navigate(screen)
     }
   }
+  onLayout = e => {
+    this.setState({
+      drawerContentWidth: e.nativeEvent.layout.width
+    })
+  }
+
   render() {
     const { lng, user, navigation } = this.props
     const { checkboxesVisible, showErrors, logingOut } = this.state
@@ -113,10 +120,14 @@ export class DrawerContent extends Component {
     const currentStack = state.routes[state.index]
 
     return (
-      <ScrollView contentContainerStyle={styles.container}>
+      <ScrollView
+        style={{ width: this.state.drawerContentWidth }}
+        contentContainerStyle={styles.container}
+        onLayout={this.onLayout}
+      >
         <View>
           <Image
-            style={{ height: 172, width: 304 }}
+            style={{ height: 172, width: this.state.drawerContentWidth }}
             source={require('../../assets/images/navigation_image.png')}
           />
           {/* Language Switcher */}

--- a/src/navigation/DrawerContent.js
+++ b/src/navigation/DrawerContent.js
@@ -20,6 +20,7 @@ import { switchLanguage, logout, updateNav } from '../redux/actions'
 import LogoutPopup from './LogoutPopup'
 import dashboardIcon from '../../assets/images/icon_dashboard.png'
 import familyNavIcon from '../../assets/images/icon_family_nav.png'
+import { isPortrait } from '../responsivenessHelpers'
 
 // Component that renders the drawer menu content. DrawerItems are the links to
 // the given views.
@@ -111,18 +112,24 @@ export class DrawerContent extends Component {
   }
 
   render() {
-    const { lng, user, navigation } = this.props
-    const { checkboxesVisible, showErrors, logingOut, drawerContentWidth } = this.state
+    const { lng, user, navigation, dimensions } = this.props
+    const {
+      checkboxesVisible,
+      showErrors,
+      logingOut,
+      drawerContentWidth
+    } = this.state
     const unsyncedDrafts = this.props.drafts.filter(
       draft => draft.status !== 'Synced'
     ).length
     const { state } = navigation
     const currentStack = state.routes[state.index]
-
+    const portrait = !!dimensions && isPortrait(dimensions)
+    
     return (
       <ScrollView
         style={{ width: drawerContentWidth }}
-        contentContainerStyle={styles.container}
+        contentContainerStyle={[!portrait ? {} : styles.container ]}
         onLayout={this.onLayout}
       >
         <View>
@@ -167,60 +174,67 @@ export class DrawerContent extends Component {
           {/* Links */}
         </View>
         <View style={styles.itemsContainer}>
-          <View>
-            <IconButton
-              id="dashboard"
-              style={{
-                ...styles.navItem,
-                backgroundColor:
-                  this.state.activeTab === 'Dashboard' ? colors.primary : null
-              }}
-              onPress={() => this.navigateToScreen('Dashboard', currentStack)}
-              imageSource={dashboardIcon}
-              text={i18n.t('views.home')}
-              textStyle={styles.label}
-            />
-            <IconButton
-              id="surveys"
-              style={{
-                ...styles.navItem,
-                backgroundColor:
-                  this.state.activeTab === 'Surveys' ? colors.primary : null
-              }}
-              onPress={() => this.navigateToScreen('Surveys', currentStack)}
-              icon="swap-calls"
-              size={20}
-              textStyle={styles.label}
-              text={i18n.t('views.createLifemap')}
-            />
-            <IconButton
-              id="families"
-              style={{
-                ...styles.navItem,
-                backgroundColor:
-                  this.state.activeTab === 'Families' ? colors.primary : null
-              }}
-              onPress={() => this.navigateToScreen('Families', currentStack)}
-              imageSource={familyNavIcon}
-              size={20}
-              text={i18n.t('views.families')}
-              textStyle={styles.label}
-            />
-            <IconButton
-              id="sync"
-              style={{
-                ...styles.navItem,
-                backgroundColor:
-                  this.state.activeTab === 'Sync' ? colors.primary : null
-              }}
-              onPress={() => this.navigateToScreen('Sync', currentStack)}
-              icon="sync"
-              size={20}
-              text={i18n.t('views.synced')}
-              textStyle={styles.label}
-              badge
-            />
-          </View>
+          <ScrollView
+            contentContainerStyle={{
+              flexGrow: 1,
+              height: 250,
+            }}
+          >
+            <View>
+              <IconButton
+                id="dashboard"
+                style={{
+                  ...styles.navItem,
+                  backgroundColor:
+                    this.state.activeTab === 'Dashboard' ? colors.primary : null
+                }}
+                onPress={() => this.navigateToScreen('Dashboard', currentStack)}
+                imageSource={dashboardIcon}
+                text={i18n.t('views.home')}
+                textStyle={styles.label}
+              />
+              <IconButton
+                id="surveys"
+                style={{
+                  ...styles.navItem,
+                  backgroundColor:
+                    this.state.activeTab === 'Surveys' ? colors.primary : null
+                }}
+                onPress={() => this.navigateToScreen('Surveys', currentStack)}
+                icon="swap-calls"
+                size={20}
+                textStyle={styles.label}
+                text={i18n.t('views.createLifemap')}
+              />
+              <IconButton
+                id="families"
+                style={{
+                  ...styles.navItem,
+                  backgroundColor:
+                    this.state.activeTab === 'Families' ? colors.primary : null
+                }}
+                onPress={() => this.navigateToScreen('Families', currentStack)}
+                imageSource={familyNavIcon}
+                size={20}
+                text={i18n.t('views.families')}
+                textStyle={styles.label}
+              />
+              <IconButton
+                id="sync"
+                style={{
+                  ...styles.navItem,
+                  backgroundColor:
+                    this.state.activeTab === 'Sync' ? colors.primary : null
+                }}
+                onPress={() => this.navigateToScreen('Sync', currentStack)}
+                icon="sync"
+                size={20}
+                text={i18n.t('views.synced')}
+                textStyle={styles.label}
+                badge
+              />
+            </View>
+          </ScrollView>
         </View>
         {/* Logout button */}
         <IconButton
@@ -269,14 +283,16 @@ DrawerContent.propTypes = {
   navigation: PropTypes.object.isRequired,
   user: PropTypes.object.isRequired,
   drafts: PropTypes.array.isRequired,
-  env: PropTypes.oneOf(['production', 'demo', 'testing', 'development'])
+  env: PropTypes.oneOf(['production', 'demo', 'testing', 'development']),
+  dimensions: PropTypes.object.isRequired,
 }
 
-const mapStateToProps = ({ env, user, drafts, nav }) => ({
+const mapStateToProps = ({ env, user, drafts, nav, dimensions }) => ({
   env,
   user,
   drafts,
-  nav
+  nav,
+  dimensions
 })
 
 const mapDispatchToProps = {


### PR DESCRIPTION
This issue closes #526 
On phone or tablet / check landscape and portrait 

White space on navigation
------------------------------
1) Open the drawer navigation
2) Try rotating your device in order to trigger landscape and portrait view. The width of the drawer's content should resize every time and you should not see the white space gap
Additional check ---> 
3) Rotate into portrait view
4) Open the drawer
5) Rotate few times your device
6) Again ... The width of the drawer's content should resize every time and you should not see the white space gap

Fucked up nav items in drawer when in landscape --- test on Phone
1) Open the drawer in portrait
2) Rotate the device into landscape
3) IN LANDSCAPE  the nav items should not stack over each other anymore . Instead the drawer's content should scroll