### PR TITLE
fix #551 improved logging time

### DIFF
--- a/src/screens/Loading.js
+++ b/src/screens/Loading.js
@@ -83,7 +83,7 @@ export class Loading extends Component {
                 name: 'GECO',
                 styleURL: MapboxGL.StyleURL.Street,
                 minZoom: 10,
-                maxZoom: 15,
+                maxZoom: 13,
                 bounds: [[-71.0187, -33.687], [-70.3036, -33.1287]]
               },
               this.onMapDownloadProgress,


### PR DESCRIPTION
i did some testign and tho problem really was in the min and maxzoom
When the minZoom was 10 and the maxZoom was 15 the loading time was 6,08 min
When the minZoom was 7 and the maxZoom was 15 the loading time was 3,35 min
When the minZoom was 10 and the maxZoom was 13 the loading time was 2 min

Currently it is minZoom 10 and maxZoom 13 because it is the most performant.
