### PR TITLE
fix #650 and #608 checkbox and text click

### DIFF
--- a/src/components/SliderItem.js
+++ b/src/components/SliderItem.js
@@ -31,7 +31,12 @@ export default class SliderItem extends Component {
   calculateTextContentHeight = event => {
     this.setState({ textContentHeight: event.nativeEvent.layout.height })
   }
-
+  pressText = () => {
+    this.setState({ pressed: true })
+    setTimeout(() => {
+      this.props.onPress()
+    }, 0)
+  }
   render() {
     const { slide, value, bodyHeight, portrait, tablet } = this.props
     const slideHeight =
@@ -42,12 +47,17 @@ export default class SliderItem extends Component {
         : bodyHeight - 100
     const imageHeight = !tablet && !portrait ? bodyHeight / 3 : bodyHeight / 2
     const textAreaHeight = slideHeight - imageHeight // - 30 is margin top on image + icon
+
     return (
       <TouchableHighlight
         activeOpacity={1}
         underlayColor={'transparent'}
         style={[styles.slide, { height: slideHeight }]}
-        onPress={this.props.onPress}
+        onPress={() =>
+          setTimeout(() => {
+            this.props.onPress()
+          }, 0)
+        }
         onHideUnderlay={() => this.togglePressedState(false)}
         onShowUnderlay={() => this.togglePressedState(true)}
         accessibilityLabel={value === slide.value ? 'selected' : 'deselected'}
@@ -64,7 +74,6 @@ export default class SliderItem extends Component {
               !tablet && !portrait ? { marginTop: 5 } : { marginTop: 10 }
             ]}
           />
-
           <View
             id="icon-view"
             style={[
@@ -96,6 +105,7 @@ export default class SliderItem extends Component {
               }}
             >
               <Text
+                onPress={() => this.pressText()}
                 onLayout={event => this.calculateTextContentHeight(event)}
                 style={[
                   {


### PR DESCRIPTION
This is a fix for both #650 and #608 .
In order to show the checkbox before navigating i had to change the onPress function to 

 onPress={() =>
          setTimeout(() => {
            this.props.onPress()
          }, 0)
     }

With setTimeout 0 it is working perfectly fine,and it is showing the checkbox before navigating to the next screen.

This pull request is for both  #650 and #608(make the text clickable) because they are related to each other and i had to implement the same function to the Text component in order to show the checkbox.





