### PR TITLE
fix #621 added refresh to the online map

### DIFF
--- a/src/screens/lifemap/Location.js
+++ b/src/screens/lifemap/Location.js
@@ -7,7 +7,8 @@ import {
   Image,
   Keyboard,
   TouchableHighlight,
-  NetInfo
+  NetInfo,
+  AppState
 } from 'react-native'
 import Geolocation from '@react-native-community/geolocation'
 /* eslint-disable import/named */
@@ -28,7 +29,6 @@ import center from '../../../assets/images/centerMap.png'
 import happy from '../../../assets/images/happy.png'
 import sad from '../../../assets/images/sad.png'
 import { getDraft, getTotalScreens } from './helpers'
-import { AppState } from 'react-native'
 
 export class Location extends Component {
   state = {

--- a/src/screens/lifemap/Location.js
+++ b/src/screens/lifemap/Location.js
@@ -28,6 +28,7 @@ import center from '../../../assets/images/centerMap.png'
 import happy from '../../../assets/images/happy.png'
 import sad from '../../../assets/images/sad.png'
 import { getDraft, getTotalScreens } from './helpers'
+import { AppState } from 'react-native'
 
 export class Location extends Component {
   state = {
@@ -42,7 +43,8 @@ export class Location extends Component {
     centeringMap: false, // while map is centering we show a different spinner
     loading: true,
     showForm: false,
-    cachedMapPacks: []
+    cachedMapPacks: [],
+    appState: AppState.currentState
   }
 
   errorsDetected = []
@@ -290,7 +292,18 @@ export class Location extends Component {
       .catch(() => {})
   }
 
+  _handleAppStateChange = nextAppState => {
+    if (
+      this.state.appState.match(/inactive|background/) &&
+      nextAppState === 'active'
+    ) {
+      this.props.navigation.replace('Location')
+    }
+    this.setState({ appState: nextAppState })
+  }
+
   componentDidMount() {
+    AppState.addEventListener('change', this._handleAppStateChange)
     this.getMapOfflinePacks()
     const { survey } = this.props.nav
     // set search location keyboard events
@@ -361,6 +374,7 @@ export class Location extends Component {
     }
   }
   componentWillUnmount() {
+    AppState.removeEventListener('change', this._handleAppStateChange)
     this.keyboardDidShowListener.remove()
     this.keyboardDidHideListener.remove()
   }
@@ -404,7 +418,6 @@ export class Location extends Component {
   render() {
     const { t } = this.props
     const { survey, readonly } = this.props.nav
-
     const {
       latitude,
       longitude,
@@ -417,7 +430,6 @@ export class Location extends Component {
     } = this.state
 
     const draft = this.props.navigation.getParam('family') || getDraft()
-
     if (loading) {
       return (
         <View style={[globalStyles.container, styles.placeholder]}>


### PR DESCRIPTION
When turning off the screen and turning it on again(after 10 sec) the map was disappearing.

The issue was not in the connection. I had to implement AppState from react-native in order to add an event Listner to see if the app is active or not.And now when you turn on the screen again the component is refreshing by re-navigating to itself. 

It is working fine, but the disadvantages are that the component is also re-rendering when you are simply playing with other apps and your screen is not turned off.
