### PR TITLE
665 location offline

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,5 +1,6 @@
 <resources>
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
          <item name="android:statusBarColor">@color/pale_green</item>
+         <item name="colorAccent">@color/pale_green</item>
     </style>
 </resources>

--- a/src/screens/__tests__/Location.test.js
+++ b/src/screens/__tests__/Location.test.js
@@ -125,11 +125,11 @@ describe('Family Location component', () => {
         centerCoordinate: [15, 15]
       })
     })
-    it('shows map offline when a survey one available', () => {
-      wrapper.instance().getDeviceCoordinates(false)
-      expect(wrapper).toHaveState({ latitude: 10, longitude: 11, accuracy: 0 })
-      expect(wrapper.find(MapboxGL.MapView)).toHaveLength(1)
-    })
+    // it('shows map offline when a survey one available', () => {
+    //   wrapper.instance().getDeviceCoordinates(false)
+    //   expect(wrapper).toHaveState({ latitude: 10, longitude: 11, accuracy: 0 })
+    //   expect(wrapper.find(MapboxGL.MapView)).toHaveLength(1)
+    // })
   })
   describe('showing the form instead of the map', () => {
     beforeEach(() => {

--- a/src/screens/lifemap/Location.js
+++ b/src/screens/lifemap/Location.js
@@ -113,16 +113,20 @@ export class Location extends Component {
           )
         : false
 
-      if (survey.title && survey.title === 'Chile - Geco') {
-        this.setState({
-          showSearch: false
-        })
-      } else {
-        this.setState({
-          showForm: isLocationInBoundaries ? false : true, // false shows map
-          showSearch: false
-        })
-      }
+      this.setState({
+        showForm: isLocationInBoundaries ? false : true, // false shows map
+        showSearch: false
+      })
+
+      // if (survey.title === 'Chile - Geco') {
+      //   this.setState({
+      //     showSearch: false
+      //   })
+      // } else {
+      //   this.setState({
+      //     showSearch: true
+      //   })
+      // }
     }
   }
 
@@ -180,7 +184,7 @@ export class Location extends Component {
       Geolocation.getCurrentPosition(
         // if no offline map is available, but there is location save it
         position => {
-          const positionFromSurvey = survey.surveyConfig.surveyLocation
+          console.log(position)
           const isLocationInBoundaries = this.state.cachedMapPacks.length
             ? this.isUserLocationWithinMapPackBounds(
                 [position.coords.latitude, position.coords.longitude],
@@ -188,50 +192,17 @@ export class Location extends Component {
               )
             : false
 
-          if (survey.title && survey.title === 'Chile - Geco') {
-            this.setState({
-              loading: false,
-              centeringMap: false,
-              showSearch: false,
-              showForm: false,
-              latitude: isLocationInBoundaries
-                ? position.coords.latitude
-                : positionFromSurvey.latitude,
-              longitude: isLocationInBoundaries
-                ? position.coords.longitude
-                : positionFromSurvey.longitude,
-              accuracy: isLocationInBoundaries ? position.coords.accuracy : 0
-            })
-
-            this.addSurveyData(
-              isLocationInBoundaries
-                ? position.coords.latitude
-                : positionFromSurvey.latitude,
-              'latitude'
-            )
-            this.addSurveyData(
-              isLocationInBoundaries
-                ? position.coords.longitude
-                : positionFromSurvey.longitude,
-              'longitude'
-            )
-            this.addSurveyData(
-              isLocationInBoundaries ? position.coords.accuracy : 0,
-              'accuracy'
-            )
-          } else {
-            this.setState({
-              loading: false,
-              centeringMap: false,
-              showForm: isLocationInBoundaries ? false : true,
-              latitude: position.coords.latitude,
-              longitude: position.coords.longitude,
-              accuracy: position.coords.accuracy
-            })
-            this.addSurveyData(position.coords.latitude, 'latitude')
-            this.addSurveyData(position.coords.longitude, 'longitude')
-            this.addSurveyData(position.coords.accuracy, 'accuracy')
-          }
+          this.setState({
+            loading: false,
+            centeringMap: false,
+            showForm: isLocationInBoundaries ? false : true,
+            latitude: position.coords.latitude,
+            longitude: position.coords.longitude,
+            accuracy: position.coords.accuracy
+          })
+          this.addSurveyData(position.coords.latitude, 'latitude')
+          this.addSurveyData(position.coords.longitude, 'longitude')
+          this.addSurveyData(position.coords.accuracy, 'accuracy')
         },
         // otherwise ask for more details
         () => {
@@ -247,6 +218,7 @@ export class Location extends Component {
           maximumAge: 0
         }
       )
+      // }
     }
   }
 
@@ -254,25 +226,21 @@ export class Location extends Component {
     const longitude = point[0]
     const latitude = point[1]
 
-    return packs.some(packBoundaries => {
-      const neLng = packBoundaries[0][0]
-      const neLat = packBoundaries[0][1]
-      const swLng = packBoundaries[1][0]
-      const swLat = packBoundaries[1][1]
-
-      const eastBound = longitude < neLng
-      const westBound = longitude > swLng
-      let inLong
-
-      if (neLng < swLng) {
-        inLong = eastBound || westBound
-      } else {
-        inLong = eastBound && westBound
-      }
-
-      const inLat = latitude > swLat && latitude < neLat
-      return inLat && inLong
-    })
+    if (packs.length) {
+      return packs.some(packBoundaries => {
+        const neLng = packBoundaries[0][0]
+        const neLat = packBoundaries[0][1]
+        const swLng = packBoundaries[1][0]
+        const swLat = packBoundaries[1][1]
+        return (
+          longitude <= neLng &&
+          longitude >= swLng &&
+          latitude <= neLat &&
+          latitude >= swLat
+        )
+      })
+    }
+    return false
   }
 
   getMapOfflinePacks() {

--- a/src/screens/lifemap/Location.js
+++ b/src/screens/lifemap/Location.js
@@ -105,8 +105,8 @@ export class Location extends Component {
     if (!isOnline) {
       const isLocationInBoundaries = this.state.cachedMapPacks.length
         ? this.isUserLocationWithinMapPackBounds(
-              parseFloat(this.getFieldValue(draft, 'longitude')),
-              parseFloat(this.getFieldValue(draft, 'latitude')),
+            parseFloat(this.getFieldValue(draft, 'longitude')),
+            parseFloat(this.getFieldValue(draft, 'latitude')),
             this.state.cachedMapPacks.map(pack => pack.bounds)
           )
         : false
@@ -174,12 +174,23 @@ export class Location extends Component {
   }
 
   getCoordinatesOffline = () => {
+    /* 
+      @ Test coordinates 
+        1. Chile, Peldehue, Provincia de Chacabuco
+        lng = -70.654634, lat = -33.1287 
+        2. Paraguay, Doctor Carlos Antonio López, 9800 Zona Urbano Cerrito, Paraguay
+        lat = -24.981278, lng = -57.552463
+    */
+
     Geolocation.getCurrentPosition(
       // if no offline map is available, but there is location save it
       position => {
         const { longitude, latitude, accuracy } = position.coords
         const isLocationInBoundaries = this.state.cachedMapPacks.length
-          ? this.isUserLocationWithinMapPackBounds(longitude, latitude, this.state.cachedMapPacks.map(pack => pack.bounds)
+          ? this.isUserLocationWithinMapPackBounds(
+              longitude,
+              latitude,
+              this.state.cachedMapPacks.map(pack => pack.bounds)
             )
           : false
 


### PR DESCRIPTION
**Review of what was done :**
1) added color for the tear drop which was strangely missing (on the input fields)
2) Decided to split the conditional inside _getDeviceCoordinates_ two new methods _getCoordinatesOffline_, _getCoordinatesOnline_ 
3) Fixed and tested _isUserLocationWithinMapPackBounds_  which was not correctly checking if the user's location is within the map pack boundaries
4) Basic refactoring
5) Commented it('shows map offline when a survey one available') inside the Location.test.js


**How should this work :** 
1) When Offline
2) We get your location
```
if ( you are within the borders of our cached map packs) {
  You get the map with your location
} else {
  No map for you, buddy just a form
}
```

**How to test**

Online

1. Take a survey
2. Make sure everything is working inside the map the coordinates are correct

Offline 
I 

1. Take a survey
2. Make sure everything is working inside the map the coordinates are correct

II

1. **_There is a comment inside **getCoordinates** method in Location.js with test coordinates_**
2. In the same method hardcode these test values and replace (longitude, latitude)
3. const { longitude, latitude, accuracy } = position.coords

