### PR TITLE
fix #680 fixed saving survey when not matching requrments

### DIFF
--- a/src/screens/lifemap/FamilyParticipant.js
+++ b/src/screens/lifemap/FamilyParticipant.js
@@ -52,16 +52,26 @@ export class FamilyParticipant extends Component {
       }
   }
 
-  detectError = (error, field) => {
+  detectError = async (error, field) => {
     if (error && !this.errorsDetected.includes(field)) {
       this.errorsDetected.push(field)
     } else if (!error) {
       this.errorsDetected = this.errorsDetected.filter(item => item !== field)
     }
+    const { navigation } = this.props
 
-    this.setState({
+    await this.setState({
       errorsDetected: this.errorsDetected
     })
+    if (this.state.errorsDetected.length) {
+      navigation.setParams({
+        isNewDraft: true
+      })
+    } else {
+      navigation.setParams({
+        isNewDraft: !navigation.getParam('draft')
+      })
+    }
   }
 
   handleClick = () => {


### PR DESCRIPTION
every time we have an error i set the isNewDraft to true,when the error disappears i change it to !navigation.getParam('draft').