### PR TITLE
fixed failing getPotentialPrioritiesCount due to missing draft and su…

### DIFF
--- a/src/screens/lifemap/Final.js
+++ b/src/screens/lifemap/Final.js
@@ -28,7 +28,9 @@ export class Final extends Component {
 
   onPressBack = () => {
     this.props.navigation.replace('Overview', {
-      resumeDraft: false
+      resumeDraft: false,
+      draft: this.draft,
+      survey: this.survey
     })
   }
 

--- a/src/screens/lifemap/Overview.js
+++ b/src/screens/lifemap/Overview.js
@@ -22,7 +22,8 @@ export class Overview extends Component {
     tipIsVisible: false,
     draft:
       this.props.navigation.getParam('draft') ||
-      this.props.navigation.getParam('familyLifemap')
+      this.props.navigation.getParam('familyLifemap') ||
+      {}
   }
 
   isDraftResuming = this.props.navigation.getParam('resumeDraft')
@@ -86,7 +87,7 @@ export class Overview extends Component {
   }
 
   navigateToScreen = (screen, indicator, indicatorText) =>
-    this.props.navigation.navigate(screen, {
+    this.props.navigation.push(screen, {
       familyLifemap: this.state.draft,
       survey: this.survey,
       indicator,
@@ -113,16 +114,23 @@ export class Overview extends Component {
   }
 
   getPotentialPrioritiesCount() {
-    return this.state.draft.indicatorSurveyDataList.filter(
-      question => question.value === 1 || question.value === 2
-    ).length
+    const { draft } = this.state
+    return (
+      draft &&
+      draft.indicatorSurveyDataList &&
+      draft.indicatorSurveyDataList.filter(
+        question => question.value === 1 || question.value === 2
+      ).length
+    )
   }
 
   getMandatoryPrioritiesCount() {
-    const potentialPrioritiesCount = this.getPotentialPrioritiesCount()
+    const potentialPrioritiesCount = this.getPotentialPrioritiesCount() || 0
+    const mimimumPriorities =
+      (this.survey && this.survey.minimumPriorities) || 0
 
-    return potentialPrioritiesCount > this.survey.minimumPriorities
-      ? this.survey.minimumPriorities
+    return potentialPrioritiesCount > mimimumPriorities
+      ? mimimumPriorities
       : potentialPrioritiesCount
   }
 

--- a/src/screens/lifemap/Question.js
+++ b/src/screens/lifemap/Question.js
@@ -141,7 +141,7 @@ export class Question extends Component {
         answer !== 0) ||
       skippedQuestions.length === 0
     ) {
-      return this.props.navigation.navigate('Overview', {
+      return this.props.navigation.push('Overview', {
         resumeDraft: false,
         draft: updatedDraft,
         survey: this.survey
@@ -174,7 +174,7 @@ export class Question extends Component {
     const { t } = this.props
     return (
       <StickyFooter
-        handleClick={this.handleClick}
+        handleClick={() => ({})}
         readonly
         progress={
           draft


### PR DESCRIPTION
The problem appears when you press the back button from the Final screen inside the onPressBack method. The error is caused by missing params for  draft and survey  

1) Take a survey with minimumPriorities (i. e. Sierra Leone)
2) Get to Overview screen and see if you get error
3) From Overview go to Final screen and press the back button until you get to the Overview screen again
4) Exit the draft from the Overview screen 
5) Resume the draft again
6) Go to Final 
7) Press back and see if you get an error 