### PR TITLE
Feature/632 downloading error handling

### DIFF
--- a/src/components/FamiliesListItem.js
+++ b/src/components/FamiliesListItem.js
@@ -39,7 +39,7 @@ class FamiliesListItem extends Component {
         disabled={family.snapshotList && !family.snapshotList.length}
       >
         <View>
-          { family.snapshotList &&
+          {family.snapshotList &&
             family.snapshotList[0] &&
             family.snapshotList[0].familyData.countFamilyMembers &&
             family.snapshotList[0].familyData.countFamilyMembers > 1 && (

--- a/src/navigation/stacks.js
+++ b/src/navigation/stacks.js
@@ -52,7 +52,7 @@ const MainNavigator = createStackNavigator(
   {
     // Default config for all screens
     headerMode: 'none',
-    initialRouteName: 'loginStack',
+    initialRouteName: 'drawerStack',
     transitionConfig: () => ({
       screenInterpolator: () => null,
       transitionSpec: {

--- a/src/redux/__tests__/actions.test.js
+++ b/src/redux/__tests__/actions.test.js
@@ -102,6 +102,7 @@ describe('families actions', () => {
       meta: {
         offline: {
           commit: { type: 'LOAD_FAMILIES_COMMIT' },
+          rollback: { type: 'LOAD_FAMILIES_ROLLBACK' },
           effect: {
             body:
               '{"query":"query { familiesNewStructure {familyId name code snapshotList { surveyId createdAt familyData { familyMembersList { birthCountry birthDate documentNumber documentType email familyId firstName firstParticipant gender id lastName memberIdentifier phoneNumber socioEconomicAnswers { key value}  }  countFamilyMembers latitude longitude country accuracy } economicSurveyDataList { key value multipleValue } indicatorSurveyDataList { key value } achievements { action indicator roadmap } priorities { action estimatedDate indicator reason } } } }"}',
@@ -128,6 +129,7 @@ describe('surveys actions', () => {
       meta: {
         offline: {
           commit: { type: 'LOAD_SURVEYS_COMMIT' },
+          rollback: { type: 'LOAD_SURVEYS_ROLLBACK' },
           effect: {
             body:
               '{"query":"query { surveysByUser { title id createdAt description minimumPriorities privacyPolicy { title  text } termsConditions{ title text }  surveyConfig { documentType {text value} gender { text value} surveyLocation { country latitude longitude}  offlineMaps { from, to, center, name } }  surveyEconomicQuestions { questionText codeName answerType topic required forFamilyMember options {text value conditions{codeName, type, values, operator, valueType, showIfNoData}}, conditions{codeName, type, value, operator}, conditionGroups{groupOperator, joinNextGroup, conditions{codeName, type, value, operator}} } surveyStoplightQuestions { questionText codeName dimension id stoplightColors { url value description } required } } }"}',

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -60,6 +60,7 @@ export const setEnv = env => ({
 
 export const LOAD_SURVEYS = 'LOAD_SURVEYS'
 export const LOAD_SURVEYS_COMMIT = 'LOAD_SURVEYS_COMMIT'
+export const LOAD_SURVEYS_ROLLBACK = 'LOAD_SURVEYS_ROLLBACK'
 
 export const loadSurveys = (env, token) => ({
   type: LOAD_SURVEYS,
@@ -76,7 +77,8 @@ export const loadSurveys = (env, token) => ({
             'query { surveysByUser { title id createdAt description minimumPriorities privacyPolicy { title  text } termsConditions{ title text }  surveyConfig { documentType {text value} gender { text value} surveyLocation { country latitude longitude}  offlineMaps { from, to, center, name } }  surveyEconomicQuestions { questionText codeName answerType topic required forFamilyMember options {text value conditions{codeName, type, values, operator, valueType, showIfNoData}}, conditions{codeName, type, value, operator}, conditionGroups{groupOperator, joinNextGroup, conditions{codeName, type, value, operator}} } surveyStoplightQuestions { questionText codeName dimension id stoplightColors { url value description } required } } }'
         })
       },
-      commit: { type: LOAD_SURVEYS_COMMIT }
+      commit: { type: LOAD_SURVEYS_COMMIT },
+      rollback: { type: LOAD_SURVEYS_ROLLBACK }
     }
   }
 })
@@ -85,6 +87,7 @@ export const loadSurveys = (env, token) => ({
 
 export const LOAD_FAMILIES = 'LOAD_FAMILIES'
 export const LOAD_FAMILIES_COMMIT = 'LOAD_FAMILIES_COMMIT'
+export const LOAD_FAMILIES_ROLLBACK = 'LOAD_FAMILIES_ROLLBACK'
 
 export const loadFamilies = (env, token) => ({
   type: LOAD_FAMILIES,
@@ -101,7 +104,8 @@ export const loadFamilies = (env, token) => ({
             'query { familiesNewStructure {familyId name code snapshotList { surveyId createdAt familyData { familyMembersList { birthCountry birthDate documentNumber documentType email familyId firstName firstParticipant gender id lastName memberIdentifier phoneNumber socioEconomicAnswers { key value}  }  countFamilyMembers latitude longitude country accuracy } economicSurveyDataList { key value multipleValue } indicatorSurveyDataList { key value } achievements { action indicator roadmap } priorities { action estimatedDate indicator reason } } } }'
         })
       },
-      commit: { type: LOAD_FAMILIES_COMMIT }
+      commit: { type: LOAD_FAMILIES_COMMIT },
+      rollback: { type: LOAD_FAMILIES_ROLLBACK }
     }
   }
 })

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -6,7 +6,9 @@ import {
   USER_LOGOUT,
   SET_ENV,
   LOAD_SURVEYS_COMMIT,
+  LOAD_SURVEYS_ROLLBACK,
   LOAD_FAMILIES_COMMIT,
+  LOAD_FAMILIES_ROLLBACK,
   CREATE_DRAFT,
   UPDATE_DRAFT,
   ADD_SURVEY_DATA,
@@ -287,7 +289,9 @@ export const sync = (
   state = {
     appVersion: null,
     surveys: false,
+    surveysError: false,
     families: false,
+    familiesError: false,
     images: {
       total: 0,
       synced: 0
@@ -317,10 +321,22 @@ export const sync = (
           total: state[action.item].total
         }
       }
+    case LOAD_SURVEYS_ROLLBACK:
+      return {
+        ...state,
+        surveysError: true
+      }
+    case LOAD_FAMILIES_ROLLBACK:
+      return {
+        ...state,
+        familiesError: true
+      }
     case RESET_SYNCED_STATE:
       return {
         surveys: false,
+        surveysError: false,
         families: false,
+        familiesError: false,
         images: {
           total: 0,
           synced: 0
@@ -420,8 +436,9 @@ export const rootReducer = (state, action) => {
       env: 'production',
       sync: {
         appVersion: null,
-        surveys: false,
+        surveysError: false,
         families: false,
+        familiesError: false,
         images: {
           total: 0,
           synced: 0

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -436,6 +436,7 @@ export const rootReducer = (state, action) => {
       env: 'production',
       sync: {
         appVersion: null,
+        surveys: false,
         surveysError: false,
         families: false,
         familiesError: false,

--- a/src/screens/Dashboard.js
+++ b/src/screens/Dashboard.js
@@ -28,6 +28,10 @@ export class Dashboard extends Component {
     red: 0
   }
   componentDidMount() {
+    if (!this.props.user.token) {
+      this.props.navigation.navigate('Login')
+    }
+
     if (UIManager.AccessibilityEventTypes) {
       setTimeout(() => {
         UIManager.sendAccessibilityEvent(

--- a/src/screens/Loading.js
+++ b/src/screens/Loading.js
@@ -50,6 +50,9 @@ export class Loading extends Component {
       (!!this.props.sync.images.total &&
         this.props.sync.images.total === this.props.sync.images.synced)
     ) {
+      if (this.unsubscribeNetChange) {
+        this.unsubscribeNetChange()
+      }
       this.props.navigation.navigate('DrawerStack')
     } else {
       this.setState({
@@ -151,13 +154,14 @@ export class Loading extends Component {
   }
 
   onMapDownloadError = () => {
-    this.showError()
+    this.showError('We seem to have a problem downloading your offline maps.')
   }
 
   reload = () => {
     this.setState({
       error: null
     })
+    this.props.resetSyncState()
     this.checkState()
   }
 
@@ -198,6 +202,9 @@ export class Loading extends Component {
       !!images.total &&
       images.total === images.synced
     ) {
+      if (this.unsubscribeNetChange) {
+        this.unsubscribeNetChange()
+      }
       // if everything is synced navigate to Dashboard
       this.props.navigation.navigate('DrawerStack')
     } else {
@@ -249,7 +256,25 @@ export class Loading extends Component {
       this.props.sync.images.total === this.props.sync.images.synced &&
       this.state.maps.every(map => map.status === 100)
     ) {
+      if (this.unsubscribeNetChange) {
+        this.unsubscribeNetChange()
+      }
       this.props.navigation.navigate('DrawerStack')
+    }
+
+    // if there is a download error
+    if (!prevProps.sync.familiesError && this.props.sync.familiesError) {
+      this.showError('We seem to have a problem downloading your families.')
+    }
+
+    if (!prevProps.sync.surveysError && this.props.sync.surveysError) {
+      this.showError('We seem to have a problem downloading your surveys.')
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.unsubscribeNetChange) {
+      this.unsubscribeNetChange()
     }
   }
 

--- a/src/screens/Login.js
+++ b/src/screens/Login.js
@@ -307,8 +307,7 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent'
   },
   logo: { width: 42, height: 42, marginBottom: 8 },
-  error: { color: colors.red, lineHeight: 15, marginBottom: 10 },
-  sadFace: { alignSelf: 'center' }
+  error: { color: colors.red, lineHeight: 15, marginBottom: 10 }
 })
 
 const mapStateToProps = ({ env, user }) => ({


### PR DESCRIPTION
We need to account for errors while downloading data during login and re-sync. We now have a simple screen with a retry button

**To Test**
Log out from the app and login again.
1. Whie downloading surveys/families disconnect the device from the internet. A retry screen should show.
2. Re-connect and hit retry. Download should succeed.
3. Modify the load surveys mutation so it will fail. Logout again and try to login. A retry screen should show.
4. Fix the surveys mutation and break the families mutation. Same should happen after surveys download.
5. While logged in an on the Home screen. Disable internet on the device. The screen should still show the Home, not Loading.
