### PR TITLE
Bugfix/947 family members count

### DIFF
--- a/src/screens/lifemap/FamilyParticipant.js
+++ b/src/screens/lifemap/FamilyParticipant.js
@@ -88,16 +88,16 @@ export class FamilyParticipant extends Component {
 
     let familyMembersList = this.state.draft.familyData.familyMembersList
 
-    const numberOfmembers =
+    const numberOfMembers =
       countFamilyMembers === PREFER_NOT_TO_SAY ? 1 : countFamilyMembers
 
-    if (value !== PREFER_NOT_TO_SAY && numberOfmembers > value) {
+    if (value !== PREFER_NOT_TO_SAY && numberOfMembers > value) {
       familyMembersList.splice(value, familyMembersList.length - 1)
     } else if (
       value !== PREFER_NOT_TO_SAY &&
-      (numberOfmembers < value || !numberOfmembers)
+      (numberOfMembers < value || !numberOfMembers)
     ) {
-      for (var i = 0; i < value - (numberOfmembers || 1); i++) {
+      for (var i = 0; i < value - (numberOfMembers || 1); i++) {
         familyMembersList.push({ firstParticipant: false })
       }
     } else if (value === PREFER_NOT_TO_SAY) {

--- a/src/screens/lifemap/FamilyParticipant.js
+++ b/src/screens/lifemap/FamilyParticipant.js
@@ -82,23 +82,25 @@ export class FamilyParticipant extends Component {
   }
 
   addFamilyCount = value => {
+    const PREFER_NOT_TO_SAY = -1
     const { draft } = this.state
     const { countFamilyMembers } = this.state.draft.familyData
 
     let familyMembersList = this.state.draft.familyData.familyMembersList
 
-    if (value !== -1 && countFamilyMembers > value) {
+    let numberOfmembers =
+      countFamilyMembers === PREFER_NOT_TO_SAY ? -1 : countFamilyMembers
+
+    if (value !== PREFER_NOT_TO_SAY && numberOfmembers > value) {
       familyMembersList.splice(value, familyMembersList.length - 1)
     } else if (
-      value !== -1 &&
-      (countFamilyMembers < value || !countFamilyMembers)
+      value !== PREFER_NOT_TO_SAY &&
+      (numberOfmembers < value || !numberOfmembers)
     ) {
-      for (var i = 0; i < value - (countFamilyMembers || 1); i++) {
+      for (var i = 0; i < value - (numberOfmembers || 1); i++) {
         familyMembersList.push({ firstParticipant: false })
       }
-    }
-
-    if (value === -1) {
+    } else if (value === PREFER_NOT_TO_SAY) {
       familyMembersList.splice(1, familyMembersList.length - 1)
     }
 
@@ -107,7 +109,7 @@ export class FamilyParticipant extends Component {
         ...draft,
         familyData: {
           ...draft.familyData,
-          countFamilyMembers: value === -1 ? 1 : value,
+          countFamilyMembers: value,
           familyMembersList
         }
       }

--- a/src/screens/lifemap/FamilyParticipant.js
+++ b/src/screens/lifemap/FamilyParticipant.js
@@ -82,14 +82,14 @@ export class FamilyParticipant extends Component {
   }
 
   addFamilyCount = value => {
-    const PREFER_NOT_TO_SAY = -1
     const { draft } = this.state
     const { countFamilyMembers } = this.state.draft.familyData
+    const PREFER_NOT_TO_SAY = -1
 
     let familyMembersList = this.state.draft.familyData.familyMembersList
 
-    let numberOfmembers =
-      countFamilyMembers === PREFER_NOT_TO_SAY ? -1 : countFamilyMembers
+    const numberOfmembers =
+      countFamilyMembers === PREFER_NOT_TO_SAY ? 1 : countFamilyMembers
 
     if (value !== PREFER_NOT_TO_SAY && numberOfmembers > value) {
       familyMembersList.splice(value, familyMembersList.length - 1)


### PR DESCRIPTION
**To Test**
1. Open Primary Participant screen
2. Go to select field "Number of people living in this household"
3. Try selecting "Prefer not to answer"
4. It should set "Prefer not to answer" as placeholder
5. Try changing the options and make sure the number of empty objects created for family members is corresponding to the family members count.
