### PR TITLE
Check for connection on login only if items are not fully cached

### DIFF
--- a/src/screens/Loading.js
+++ b/src/screens/Loading.js
@@ -263,13 +263,6 @@ export class Loading extends Component {
       }
     })
 
-    // check connection state
-    NetInfo.fetch().then(state => {
-      if (!state.isConnected) {
-        this.showError('There seems to be a problem with your connetion.')
-      }
-    })
-
     const { families, surveys, images, appVersion, maps } = this.props.sync
 
     if (!this.props.user.token) {
@@ -291,7 +284,14 @@ export class Loading extends Component {
       // if everything is synced navigate to Dashboard
       this.props.navigation.navigate('DrawerStack')
     } else {
-      this.syncSurveys()
+      // check connection state
+      NetInfo.fetch().then(state => {
+        if (!state.isConnected) {
+          this.showError('There seems to be a problem with your connetion.')
+        } else {
+          this.syncSurveys()
+        }
+      })
     }
   }
 

--- a/src/screens/Login.js
+++ b/src/screens/Login.js
@@ -64,11 +64,9 @@ export class Login extends Component {
   }
 
   setConnectivityState = isConnected => {
-    if (isConnected !== this.state.connection) {
-      isConnected
-        ? this.setState({ connection: true, error: '' })
-        : this.setState({ connection: false, error: 'No connection' })
-    }
+    isConnected
+      ? this.setState({ connection: true, error: '' })
+      : this.setState({ connection: false, error: 'No connection' })
   }
 
   setDimensions = () => {

--- a/src/screens/__tests__/Login.test.js
+++ b/src/screens/__tests__/Login.test.js
@@ -93,7 +93,7 @@ describe('Login View', () => {
       wrapper.instance().setConnectivityState(false)
       wrapper.update()
       expect(wrapper.instance().state.connection).toBe(false)
-      expect(wrapper.instance().state.error).toBe(false)
+      expect(wrapper.instance().state.error).toBe('No connection')
     })
   })
 })


### PR DESCRIPTION
There is a moment when going back to Dashboard from draft opens the Loading cycle which check for cached items. If user is offline it will show a warning message instead of moving back to dashboard. This only happens the first time after loging into an account.

**To Test**
1. Log into `d/geco`, pass: `123456`
2. After caching is done, go offline.
3. Open the one survey there is and navigate to socio economics.
4. In socio economics exit the draft.
5. Make sure you are navigated to the Dashboard without any weird messages.
