### PR TITLE
fixed checboxes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6174,7 +6174,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6192,11 +6193,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6209,15 +6212,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6320,7 +6326,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6330,6 +6337,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6342,17 +6350,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6369,6 +6380,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6441,7 +6453,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6451,6 +6464,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6526,7 +6540,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6556,6 +6571,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6573,6 +6589,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6611,11 +6628,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -74,17 +74,14 @@ class Checkbox extends Component {
           >
             <CheckBox
               disabled
-              title={`${this.props.title}${showErrors && !checked ? ' *' : ''}`}
+              title={this.props.title}
               iconType="material"
               checkedColor={checkboxColor || colors.palegreen}
               checkedIcon="check-box"
               uncheckedIcon="check-box-outline-blank"
               checked={checked}
               containerStyle={containerStyle || styles.containerStyle}
-              textStyle={[
-                textStyle || styles.label,
-                showErrors && !checked ? styles.error : {}
-              ]}
+              textStyle={[textStyle || styles.label]}
               accessibilityLabel={`${this.props.title}${
                 showErrors && !checked ? ' *' : ''
               } ${checked === true ? 'checked' : 'unchecked'}`}


### PR DESCRIPTION
The checkboxes would turn red after clicked continue even though they are not mandatory.
This happens because there is an error on the SocioEcomic page (for example trying to continue while some of the mandatory questions are not filled (not checkboxes)), i removed the change in styling if there is an error . Because the answers do not have to change to red if there is an error.