### PR TITLE
Feature/disable drawer

### DIFF
--- a/src/navigation/DrawerNavigator.js
+++ b/src/navigation/DrawerNavigator.js
@@ -13,7 +13,13 @@ export default createDrawerNavigator(
       screen: DashboardStack
     },
     Surveys: {
-      screen: LifemapStack
+      screen: LifemapStack,
+      // Enable drawer when choosing a survey and disable it after that,
+      // when creating a Life Map
+      navigationOptions: ({ navigation }) => ({
+        drawerLockMode:
+          navigation.state.index === 0 ? 'unlocked' : 'locked-closed'
+      })
     },
     Families: {
       screen: FamiliesStack


### PR DESCRIPTION
**Describe the changes**
Disabled opening the side nav when taking a survey. This one should also solve issue #997 

**To Test**
When testing , please refer to issue #997 and check that as well. Try setting language at the beginning of a survey. 1) Set language to ES 2) Take Chile survey 3) In socio economic screen in the numeric field try typing some number you should see dots if you selected "ES" in the sidebar

1. Dashboard --> create a life map
2. When the screen shows the list of surveys try opening the sidebar nav --> you should be able to do it
3. Then on every screen right after the Surveys list (Terms, Privacy, Primary Participant, e.t.c.) try opening the side bar you should not be able to do so.


