### PR TITLE
Fix deny bug and offline bug - LOCATION

### DIFF
--- a/src/screens/lifemap/Location.js
+++ b/src/screens/lifemap/Location.js
@@ -92,7 +92,9 @@ export class Location extends Component {
   // if the user has draged the map and the draft has stored some coordinates
   setCoordinatesFromDraft = isOnline => {
     const draft = !this.readOnly ? this.getDraft() : this.readOnlyDraft
+
     const { familyData } = draft
+
     this.setState({
       loading: false,
       centeringMap: false

--- a/src/screens/lifemap/Location.js
+++ b/src/screens/lifemap/Location.js
@@ -117,7 +117,7 @@ export class Location extends Component {
   getCoordinatesOnline() {
     const draft = !this.readOnly ? this.getDraft() : this.readOnlyDraft
     const { familyData } = draft
-    // this.setState({ askingForPermission: true })
+    this.setState({ askingForPermission: true })
     Geolocation.getCurrentPosition(
       // if location is available and we are online center on it
       position => {
@@ -177,7 +177,7 @@ export class Location extends Component {
   getCoordinatesOffline() {
     const draft = !this.readOnly ? this.getDraft() : this.readOnlyDraft
     const { familyData } = draft
-
+    this.setState({ askingForPermission: true })
     if (
       this.survey.surveyConfig.offlineMaps &&
       !this.state.showOfflineMapsList
@@ -277,7 +277,6 @@ export class Location extends Component {
 
   updateFamilyData = (value, field) => {
     const draft = !this.readOnly ? this.getDraft() : this.readOnlyDraft
-
     this.props.updateDraft({
       ...draft,
       familyData: {
@@ -370,10 +369,23 @@ export class Location extends Component {
   }
 
   async requestLocationPermission() {
-    const isGranted = await MapboxGL.requestAndroidLocationPermissions()
     this.setState({
-      askingForPermission: isGranted
+      askingForPermission: true
     })
+
+    let isGranted = await MapboxGL.requestAndroidLocationPermissions()
+
+    if (isGranted) {
+      this.setState({
+        askingForPermission: false,
+        loading: false
+      })
+    } else {
+      this.setState({
+        showForm: true,
+        loading: false
+      })
+    }
   }
 
   isUserLocationWithinMapPackBounds(longitude, latitude, packs) {


### PR DESCRIPTION
there were 2 bugs in the location - first is we deny the location ,then the permission popup would persist. WE did not handle the deny logic at all. i fixed that .

The second one was that if i am offline and navigate to the locations screen the app would crash.
#1073 
#1072 