### PR TITLE
Add notification modal for api warnings

### DIFF
--- a/src/components/NotificationModal.js
+++ b/src/components/NotificationModal.js
@@ -1,0 +1,67 @@
+import React, { Component } from 'react'
+import { StyleSheet, Text, View } from 'react-native'
+
+import Icon from 'react-native-vector-icons/MaterialIcons'
+import PropTypes from 'prop-types'
+import colors from '../theme.json'
+
+class NotificationModal extends Component {
+  render() {
+    const { label, subLabel } = this.props
+
+    return this.props.isOpen ? (
+      <View style={styles.wrapper}>
+        <Icon
+          style={styles.closeButton}
+          color={'#fff'}
+          onPress={this.props.onClose}
+          name="close"
+          size={24}
+          accessible={true}
+          accessibilityLabel={'Close'}
+        />
+        {label && <Text style={styles.label}>{label}</Text>}
+        {subLabel && (
+          <Text style={[styles.label, styles.sublabel]}>
+            {this.props.subLabel}
+          </Text>
+        )}
+      </View>
+    ) : null
+  }
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    backgroundColor: colors.red,
+    paddingVertical: 16,
+    paddingHorizontal: 31,
+    position: 'relative'
+  },
+  label: {
+    color: '#fff',
+    fontFamily: 'Poppins',
+    fontSize: 18,
+    fontWeight: '500',
+    letterSpacing: 0.15,
+    lineHeight: 25,
+    textAlign: 'center'
+  },
+  sublabel: {
+    fontWeight: 'normal'
+  },
+  closeButton: {
+    top: 14,
+    right: 17,
+    position: 'absolute'
+  }
+})
+
+NotificationModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  label: PropTypes.string,
+  subLabel: PropTypes.string
+}
+
+export default NotificationModal

--- a/src/components/__tests__/NotificationModal.test.js
+++ b/src/components/__tests__/NotificationModal.test.js
@@ -1,0 +1,56 @@
+import { Text, View } from 'react-native'
+
+import Icon from 'react-native-vector-icons/MaterialIcons'
+import NotificationModal from '../NotificationModal'
+import React from 'react'
+import { shallow } from 'enzyme'
+
+const createTestProps = props => ({
+  isOpen: true,
+  onClose: jest.fn(),
+  label: 'This is a modal',
+  subLabel: 'Some notes',
+  ...props
+})
+
+let wrapper
+let props
+
+beforeEach(() => {
+  props = createTestProps()
+  wrapper = shallow(<NotificationModal {...props} />)
+})
+
+it('shows it\'s contents', () => {
+  const labels = wrapper.find(Text)
+
+  expect(labels.first()).toHaveHTML(
+    '<react-native-mock>This is a modal</react-native-mock>'
+  )
+
+  expect(labels.last()).toHaveHTML(
+    '<react-native-mock>Some notes</react-native-mock>'
+  )
+})
+
+it('fires on close property function when closed', () => {
+  wrapper
+    .find(Icon)
+    .props()
+    .onPress()
+
+  expect(props.onClose).toHaveBeenCalledTimes(1)
+})
+
+it('doesn\'t show when isOpen is false', () => {
+  props = createTestProps({ isOpen: false })
+  wrapper = shallow(<NotificationModal {...props} />)
+  expect(wrapper.find(View)).toHaveLength(0)
+})
+
+it('shows empty modal if not labels are provided', () => {
+  props = createTestProps({ label: null, subLabel: null })
+  wrapper = shallow(<NotificationModal {...props} />)
+  expect(wrapper.find(View)).toHaveLength(1)
+  expect(wrapper.find(Text)).toHaveLength(0)
+})

--- a/src/config.json
+++ b/src/config.json
@@ -4,5 +4,6 @@
     "demo": "https://demo.backend.povertystoplight.org",
     "testing": "https://testing.backend.povertystoplight.org",
     "development": "http://localhost:8080"
-  }
+  },
+  "supported_API_version": "1.8.1"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -26,7 +26,9 @@
     "create": "Create",
     "confirm": "Confirm",
     "download": "Download",
-    "print": "Print"
+    "print": "Print",
+    "attention": "Important!",
+    "syncAll": "Sync all Life Maps & update the application!"
   },
   "validation": {
     "fieldIsRequired": "This field is required",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -26,7 +26,9 @@
     "create": "Crear",
     "confirm": "Confirmar",
     "download": "Descargar",
-    "print": "Imprimir"
+    "print": "Imprimir",
+    "attention": "¡Atención!",
+    "syncAll": "¡Sincroniza todos los Mapas de Vida y actualiza la aplicación!"
   },
   "validation": {
     "fieldIsRequired": "Este campo es requerido",

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -218,6 +218,7 @@ export const submitDraft = (env, token, id, payload) => {
 }
 
 // Language
+
 export const SWITCH_LANGUAGE = 'SWITCH_LANGUAGE'
 
 export const switchLanguage = language => ({
@@ -226,6 +227,7 @@ export const switchLanguage = language => ({
 })
 
 // Store Hydration
+
 export const SET_HYDRATED = 'SET_HYDRATED'
 
 export const setHydrated = () => ({
@@ -233,6 +235,7 @@ export const setHydrated = () => ({
 })
 
 // Sync
+
 export const SET_SYNCED_ITEM_TOTAL = 'SET_SYNCED_ITEM_TOTAL'
 export const SET_SYNCED_ITEM_AMOUNT = 'SET_SYNCED_ITEM_AMOUNT'
 export const SET_SYNCED_STATE = 'SET_SYNCED_STATE'
@@ -264,4 +267,19 @@ export const setAppVersion = value => ({
 
 export const resetSyncState = () => ({
   type: RESET_SYNCED_STATE
+})
+
+// API Versioning
+
+export const TOGGLE_API_VERSION_MODAL = 'TOGGLE_API_VERSION_MODAL'
+export const MARK_VERSION_CHECKED = 'MARK_VERSION_CHECKED'
+
+export const markVersionCheked = timestamp => ({
+  type: MARK_VERSION_CHECKED,
+  timestamp
+})
+
+export const toggleAPIVersionModal = isOpen => ({
+  type: TOGGLE_API_VERSION_MODAL,
+  isOpen
 })

--- a/src/redux/reducer.js
+++ b/src/redux/reducer.js
@@ -6,6 +6,7 @@ import {
   LOAD_FAMILIES_ROLLBACK,
   LOAD_SURVEYS_COMMIT,
   LOAD_SURVEYS_ROLLBACK,
+  MARK_VERSION_CHECKED,
   RESET_SYNCED_STATE,
   SET_DIMENSIONS,
   SET_DOWNLOADMAPSIMAGES,
@@ -19,6 +20,7 @@ import {
   SUBMIT_DRAFT_COMMIT,
   SUBMIT_DRAFT_ROLLBACK,
   SWITCH_LANGUAGE,
+  TOGGLE_API_VERSION_MODAL,
   UPDATE_DRAFT,
   USER_LOGOUT
 } from './actions'
@@ -64,7 +66,6 @@ export const env = (state = 'production', action) => {
 }
 
 //Download Maps or images
-
 export const downloadMapsAndImages = (
   state = { downloadMaps: true, downloadImages: true },
   action
@@ -78,7 +79,6 @@ export const downloadMapsAndImages = (
 }
 
 //Dimensions
-
 export const dimensions = (
   state = { width: null, height: null, scale: null },
   action
@@ -323,6 +323,31 @@ export const sync = (
   }
 }
 
+// API Versioning
+export const apiVersion = (
+  state = {
+    showModal: false,
+    timestamp: null
+  },
+  action
+) => {
+  switch (action.type) {
+    case TOGGLE_API_VERSION_MODAL:
+      return {
+        ...state,
+        showModal: action.isOpen
+      }
+    case MARK_VERSION_CHECKED:
+      return {
+        ...state,
+        timestamp: action.timestamp
+      }
+
+    default:
+      return state
+  }
+}
+
 const appReducer = combineReducers({
   env,
   user,
@@ -333,7 +358,8 @@ const appReducer = combineReducers({
   hydration,
   sync,
   dimensions,
-  downloadMapsAndImages
+  downloadMapsAndImages,
+  apiVersion
 })
 
 export const rootReducer = (state, action) => {

--- a/src/screens/Dashboard.js
+++ b/src/screens/Dashboard.js
@@ -342,16 +342,19 @@ export class Dashboard extends Component {
                     >
                       <View style={styles.dropdown}>
                         <FilterListItem
+                          id="all"
                           dashboard
                           onPress={() => this.selectFilter(false)}
                           text={'All Life Maps'}
                         />
                         <FilterListItem
+                          id="drafts"
                           dashboard
                           onPress={() => this.selectFilter('Draft', 'Drafts')}
                           text={'Drafts'}
                         />
                         <FilterListItem
+                          id="pending"
                           dashboard
                           onPress={() =>
                             this.selectFilter('Pending sync', 'Sync Pending')
@@ -359,6 +362,7 @@ export class Dashboard extends Component {
                           text={'Sync Pending'}
                         />
                         <FilterListItem
+                          id="error"
                           dashboard
                           onPress={() =>
                             this.selectFilter('Sync error', 'Sync Error')
@@ -366,6 +370,7 @@ export class Dashboard extends Component {
                           text={'Sync Error'}
                         />
                         <FilterListItem
+                          id="synced"
                           dashboard
                           onPress={() =>
                             this.selectFilter('Synced', 'Completed')

--- a/src/screens/Dashboard.js
+++ b/src/screens/Dashboard.js
@@ -1,26 +1,30 @@
 import {
   FlatList,
+  Image,
   ScrollView,
   StyleSheet,
   Text,
+  TouchableHighlight,
   UIManager,
   View,
-  findNodeHandle,
-  Image,
-  TouchableHighlight
+  findNodeHandle
 } from 'react-native'
 import React, { Component } from 'react'
+import { markVersionCheked, toggleAPIVersionModal } from '../redux/actions'
+import { supported_API_version, url } from '../config'
 
 import { AndroidBackHandler } from 'react-navigation-backhandler'
+import BottomModal from '../components/BottomModal'
 import Button from '../components/Button'
 import Decoration from '../components/decoration/Decoration'
 import DraftListItem from '../components/DraftListItem'
-import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
 import FilterListItem from '../components/FilterListItem'
-import BottomModal from '../components/BottomModal'
-import arrow from '../../assets/images/selectArrow.png'
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons'
+import NetInfo from '@react-native-community/netinfo'
+import NotificationModal from '../components/NotificationModal'
 import PropTypes from 'prop-types'
 import RoundImage from '../components/RoundImage'
+import arrow from '../../assets/images/selectArrow.png'
 import colors from '../theme.json'
 import { connect } from 'react-redux'
 import globalStyles from '../globalStyles'
@@ -101,10 +105,15 @@ export class Dashboard extends Component {
   navigateToCreateLifemap = () => {
     this.props.navigation.navigate('Surveys')
   }
+
   toggleFilterModal = () => {
     this.setState({
       filterModalIsOpen: !this.state.filterModalIsOpen
     })
+  }
+
+  onNotificationClose = () => {
+    this.props.toggleAPIVersionModal(false)
   }
 
   selectFilter = (filter, label) => {
@@ -129,10 +138,57 @@ export class Dashboard extends Component {
       })
     }
   }
+
+  checkAPIVersion() {
+    const { timestamp } = this.props.apiVersion
+
+    // when this was last checked
+    if (
+      !timestamp ||
+      (timestamp && new Date() - new Date(timestamp) > 24 * 60 * 60 * 1000)
+    ) {
+      // check simply if user is online
+      NetInfo.fetch().then(state => {
+        if (state.isConnected) {
+          // check the API version status compared
+          // to the supported version in config
+          fetch(`${url[this.props.env]}/graphql`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${this.props.user.token}`,
+              'content-type': 'application/json;charset=utf8'
+            },
+            body: JSON.stringify({
+              query:
+                'query apiVersionStatus($version:String) { apiVersionStatus(version:$version) {id,status,supportWindow,supportWindowTime,major,minor,patch,version} }',
+              variables: {
+                version: supported_API_version
+              }
+            })
+          })
+            .then(response => {
+              if (response.status === 200) {
+                return response.json()
+              }
+            })
+            .then(json => {
+              this.props.markVersionCheked(new Date())
+              if (json.data.apiVersionStatus.status !== 'up-to-date') {
+                this.props.toggleAPIVersionModal(true)
+              }
+            })
+            .catch(e => e)
+        }
+      })
+    }
+  }
+
   componentDidMount() {
+    // if user has no token navigate to login screen
     if (!this.props.user.token) {
       this.props.navigation.navigate('Login')
     } else {
+      this.checkAPIVersion()
       if (UIManager.AccessibilityEventTypes) {
         setTimeout(() => {
           UIManager.sendAccessibilityEvent(
@@ -147,13 +203,22 @@ export class Dashboard extends Component {
   render() {
     const { t, families, drafts } = this.props
     const { filterModalIsOpen } = this.state
+
     const allDraftFamilies = drafts.filter(
       d => d.status === 'Draft' || d.status === 'Pending sync'
     ).length
+
     const countFamilies = families.length + allDraftFamilies
+
     return (
       <AndroidBackHandler onBackPress={() => true}>
         <View style={globalStyles.ViewMainContainer}>
+          <NotificationModal
+            isOpen={this.props.apiVersion.showModal}
+            onClose={this.onNotificationClose}
+            label={t('general.attention')}
+            subLabel={t('general.syncAll')}
+          ></NotificationModal>
           <ScrollView
             contentContainerStyle={
               drafts.length
@@ -425,11 +490,13 @@ const styles = StyleSheet.create({
 
 Dashboard.propTypes = {
   navigation: PropTypes.object.isRequired,
+  toggleAPIVersionModal: PropTypes.func.isRequired,
+  markVersionCheked: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
   drafts: PropTypes.array.isRequired,
   env: PropTypes.oneOf(['production', 'demo', 'testing', 'development']),
   user: PropTypes.object.isRequired,
-
+  apiVersion: PropTypes.object.isRequired,
   offline: PropTypes.object,
   lng: PropTypes.string.isRequired,
   surveys: PropTypes.array,
@@ -445,7 +512,8 @@ export const mapStateToProps = ({
   string,
   surveys,
   families,
-  sync
+  sync,
+  apiVersion
 }) => ({
   env,
   user,
@@ -454,10 +522,11 @@ export const mapStateToProps = ({
   string,
   surveys,
   families,
-  sync
+  sync,
+  apiVersion
 })
 
-const mapDispatchToProps = {}
+const mapDispatchToProps = { markVersionCheked, toggleAPIVersionModal }
 
 export default withNamespaces()(
   connect(

--- a/src/screens/Login.js
+++ b/src/screens/Login.js
@@ -1,33 +1,34 @@
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
 import {
+  AppState,
+  Dimensions,
+  Image,
   ScrollView,
+  StyleSheet,
   Text,
   TextInput,
-  Image,
-  StyleSheet,
-  View,
-  Dimensions,
-  AppState
+  View
 } from 'react-native'
-import DeviceInfo from 'react-native-device-info'
-import { connect } from 'react-redux'
-import { CheckBox } from 'react-native-elements'
-import NetInfo from '@react-native-community/netinfo'
-import {
-  setEnv,
-  login,
-  setDimensions,
-  setDownloadMapsAndImages
-} from '../redux/actions'
-import logo from '../../assets/images/logo.png'
-import { url } from '../config'
-import globalStyles from '../globalStyles'
-import colors from '../theme.json'
-import Button from '../components/Button'
 import InternalStorageFullModal, {
   MINIMUM_REQUIRED_STORAGE_SPACE_500_MB
 } from './modals/InternalStorageFullModal'
+import React, { Component } from 'react'
+import {
+  login,
+  setDimensions,
+  setDownloadMapsAndImages,
+  setEnv
+} from '../redux/actions'
+
+import Button from '../components/Button'
+import { CheckBox } from 'react-native-elements'
+import DeviceInfo from 'react-native-device-info'
+import NetInfo from '@react-native-community/netinfo'
+import PropTypes from 'prop-types'
+import colors from '../theme.json'
+import { connect } from 'react-redux'
+import globalStyles from '../globalStyles'
+import logo from '../../assets/images/logo.png'
+import { url } from '../config'
 const TestFairy = require('react-native-testfairy')
 // get env
 const nodeEnv = process.env

--- a/src/screens/__tests__/Dashboards.test.js
+++ b/src/screens/__tests__/Dashboards.test.js
@@ -1,4 +1,8 @@
-import { Dashboard } from '../Dashboard'
+import { Dashboard, mapStateToProps } from '../Dashboard'
+
+import { AndroidBackHandler } from 'react-navigation-backhandler'
+import BottomModal from '../../components/BottomModal'
+import DraftListItem from '../../components/DraftListItem'
 import { FlatList } from 'react-native'
 import React from 'react'
 import { shallow } from 'enzyme'
@@ -23,9 +27,14 @@ const createTestProps = props => ({
   ...props
 })
 
+let wrapper
+let props
+beforeEach(() => {
+  props = createTestProps()
+  wrapper = shallow(<Dashboard {...props} />)
+})
+
 it('clicking create new lifemap navigates to proper screen', () => {
-  const props = createTestProps({})
-  const wrapper = shallow(<Dashboard {...props} />)
   wrapper
     .find('#create-lifemap')
     .props()
@@ -35,13 +44,124 @@ it('clicking create new lifemap navigates to proper screen', () => {
   expect(props.navigation.navigate).toHaveBeenCalledWith('Surveys')
 })
 it('receives empty data as props', () => {
-  const props = createTestProps({})
-  const wrapper = shallow(<Dashboard {...props} />)
   expect(wrapper.find(FlatList).props().data).toEqual([])
 })
 
-it('receives not empty data as props', () => {
-  const props = createTestProps({ drafts: [{ banica: 0 }] })
-  const wrapper = shallow(<Dashboard {...props} />)
-  expect(wrapper.find(FlatList).props().data).toEqual([{ banica: 0 }])
+it('sorts drafts by latest first', () => {
+  const drafts = [{ id: 1 }, { id: 2 }]
+  props = createTestProps({ drafts })
+  wrapper = shallow(<Dashboard {...props} />)
+
+  const list = wrapper.find(FlatList)
+
+  expect(list.props().data).toEqual(drafts.slice().reverse())
+  expect(list.props().keyExtractor(drafts[0], 0)).toEqual('0')
+  expect(list.props().renderItem({ item: drafts[0] })).toEqual(
+    <DraftListItem
+      handleClick={expect.any(Function)}
+      item={drafts[0]}
+      lng="en"
+    />
+  )
+})
+
+it('maps proper state', () => {
+  expect(mapStateToProps({ env: 'test' })).toEqual({ env: 'test' })
+})
+
+it('disables back button', () => {
+  expect(
+    wrapper
+      .find(AndroidBackHandler)
+      .props()
+      .onBackPress()
+  ).toBe(true)
+})
+
+it('redirects to login if user has no token', () => {
+  props = createTestProps({ user: { token: null } })
+  wrapper = shallow(<Dashboard {...props} />)
+
+  expect(props.navigation.navigate).toHaveBeenCalledWith('Login')
+})
+
+describe('filtering drafts', () => {
+  beforeEach(() => {
+    props = createTestProps({
+      drafts: [
+        { id: 1, status: 'Draft' },
+        { id: 2, status: 'Draft' },
+        { id: 3, status: 'Draft' },
+        { id: 4, status: 'Synced' },
+        { id: 5, status: 'Sync Error' },
+        { id: 6, status: 'Sync Error' }
+      ]
+    })
+    wrapper = shallow(<Dashboard {...props} />)
+  })
+
+  it('shows only drafts', () => {
+    wrapper
+      .find('#drafts')
+      .props()
+      .onPress()
+
+    expect(wrapper.state().filteredDrafts).toHaveLength(3)
+
+    expect(wrapper).toHaveState({ renderFiltered: true })
+
+    wrapper
+      .find('#all')
+      .props()
+      .onPress()
+
+    expect(wrapper).toHaveState({ renderFiltered: false })
+  })
+
+  it('shows only synced lifemaps', () => {
+    wrapper
+      .find('#synced')
+      .props()
+      .onPress()
+
+    expect(wrapper.state().filteredDrafts).toHaveLength(1)
+  })
+
+  it('shows errors', () => {
+    wrapper
+      .find('#pending')
+      .props()
+      .onPress()
+
+    expect(wrapper.state().filteredDrafts).toHaveLength(0)
+
+    wrapper
+      .find('#error')
+      .props()
+      .onPress()
+
+    expect(wrapper.state().filteredDrafts).toHaveLength(0)
+  })
+
+  it('resets filters when clicking outside modal', () => {
+    expect(wrapper).toHaveState({ filterModalIsOpen: false })
+
+    wrapper
+      .find('#filters')
+      .props()
+      .onPress()
+
+    expect(wrapper).toHaveState({ filterModalIsOpen: true })
+
+    wrapper
+      .find(BottomModal)
+      .props()
+      .onEmptyClose()
+
+    expect(wrapper).toHaveState({ filterModalIsOpen: false })
+  })
+})
+
+describe('checxking API version', () => {
+  it('', () => {})
 })

--- a/src/screens/__tests__/Dashboards.test.js
+++ b/src/screens/__tests__/Dashboards.test.js
@@ -1,9 +1,12 @@
-import React from 'react'
-import { shallow } from 'enzyme'
 import { Dashboard } from '../Dashboard'
 import { FlatList } from 'react-native'
+import React from 'react'
+import { shallow } from 'enzyme'
 
 const createTestProps = props => ({
+  toggleAPIVersionModal: jest.fn(),
+  markVersionCheked: jest.fn(),
+  apiVersion: { timestamp: null, showModal: false },
   navigation: {
     getParam: () => true,
     navigate: jest.fn(),
@@ -42,5 +45,3 @@ it('receives not empty data as props', () => {
   const wrapper = shallow(<Dashboard {...props} />)
   expect(wrapper.find(FlatList).props().data).toEqual([{ banica: 0 }])
 })
-
-//sorry dan, Bjorn made me do it


### PR DESCRIPTION
This adds a check for API version in the dashboard screen. It happens every once a day. This is not possible to test in normal app use. You have to simulate the actual api call. To do that you can edit what is being returned from the promise: https://github.com/FundacionParaguaya/MentorApp/blob/70f53eeff7edda8ed146f0a6e084d948537f6bfb/src/screens/Dashboard.js#L169-L173

Or edit the expected status to something else which will produce the message:
https://github.com/FundacionParaguaya/MentorApp/blob/70f53eeff7edda8ed146f0a6e084d948537f6bfb/src/screens/Dashboard.js#L174-L179

After closing the notification it should not be visible on next visit to Dashboard or on next refresh, until timeout passes. You can edit the last check timestamp to be something like a few seconds to test.