### PR TITLE
bugfix/location-offline-permission-crash-#1094

### DIFF
--- a/src/screens/lifemap/Location.js
+++ b/src/screens/lifemap/Location.js
@@ -474,29 +474,9 @@ export class Location extends Component {
     }
   }
 
-  componentDidMount() {
+  componentDidMount = async () => {
     this.setState({
       loading: true
-    })
-
-    if (!this.readOnly) {
-      this.requestLocationPermission()
-    }
-
-    // check if online first
-    NetInfo.fetch().then(state => {
-      this.determineScreenState(state.isConnected)
-      this.setState({ status: state.isConnected })
-    })
-
-    // monitor for connection changes
-    this.unsubscribeNetChange = NetInfo.addEventListener(state => {
-      const { status } = this.state
-
-      if (status !== undefined && status !== state.isConnected) {
-        this.setState({ status: state.isConnected })
-        this.determineScreenState(state.isConnected)
-      }
     })
 
     const draft = !this.readOnly ? this.getDraft() : this.readOnlyDraft
@@ -517,7 +497,6 @@ export class Location extends Component {
         }
       })
     }
-
     AppState.addEventListener('change', this._handleAppStateChange)
     this.getMapOfflinePacks()
 
@@ -530,6 +509,27 @@ export class Location extends Component {
       'keyboardDidHide',
       this._keyboardDidHide
     )
+    //before getting the coordinates with Geolocation.getCurrentPosition,
+    //we first need to wait for user permission.Otherwise the app will crash if offline.
+    if (!this.readOnly) {
+      await this.requestLocationPermission()
+    }
+
+    // check if online first
+    NetInfo.fetch().then(state => {
+      this.determineScreenState(state.isConnected)
+      this.setState({ status: state.isConnected })
+    })
+
+    // monitor for connection changes
+    this.unsubscribeNetChange = NetInfo.addEventListener(state => {
+      const { status } = this.state
+
+      if (status !== undefined && status !== state.isConnected) {
+        this.setState({ status: state.isConnected })
+        this.determineScreenState(state.isConnected)
+      }
+    })
   }
 
   shouldComponentUpdate() {


### PR DESCRIPTION
The bug was:
1)Log in the app from scratch
2)Become offline
3)Go to a random survey
4)On the Locations screen the app will crash because it will try to get the device coordinates (Geolocation.getCurrentPosition) without having the permission to do so.

The fix is:
Wait for the user to give the permission and then do the other stuff.

The main changes are : 
-I made the permission request asynchronous, which means we first wait for the user to accept/deny the permission and then we do the other stuff.

-I rearranged the flow in witch the componentDidMount executes the stuff, so the permission and the connection listener is the last. Because of the tests - since the permission is asynchronous now , some of the tests are failing because we did not accept/deny the permission.If you have an idea how we can fix that, then i would love to discuss that. However the rearranging of the items does the trick without any change in the logic.