### PR TITLE
bugfix/possible-rnFetchBlob-fix

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
+      android:largeHeap="true"
       android:name=".MainApplication"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
implemented android:largeHeap="true".

This should fix the outOfMemory error we have on older devices while caching 2000+ images.
looks like most outOfMemory errors were fixed by adding that to androidManifest.

https://github.com/react-native-community/react-native-camera/issues/590
https://github.com/facebook/react-native/issues/6799
https://stackoverflow.com/questions/27547942/out-of-memory-on-a-4320016-byte-allocation
