### PR TITLE
add check if incoming value is number inside addFamilyCount method on…

### DIFF
--- a/src/screens/lifemap/FamilyParticipant.js
+++ b/src/screens/lifemap/FamilyParticipant.js
@@ -102,17 +102,26 @@ export class FamilyParticipant extends Component {
 
     const numberOfMembers =
       countFamilyMembers === PREFER_NOT_TO_SAY ? 1 : countFamilyMembers
+    const valueIsNumber = typeof value === 'number'
 
-    if (value !== PREFER_NOT_TO_SAY && numberOfMembers > value) {
+    if (
+      valueIsNumber &&
+      value !== PREFER_NOT_TO_SAY &&
+      numberOfMembers > value
+    ) {
       familyMembersList.splice(value, familyMembersList.length - 1)
     } else if (
+      valueIsNumber &&
       value !== PREFER_NOT_TO_SAY &&
       (numberOfMembers < value || !numberOfMembers)
     ) {
       for (var i = 0; i < value - (numberOfMembers || 1); i++) {
         familyMembersList.push({ firstParticipant: false })
       }
-    } else if (value === PREFER_NOT_TO_SAY) {
+    } else if (
+      (valueIsNumber && value === PREFER_NOT_TO_SAY) ||
+      !valueIsNumber
+    ) {
       familyMembersList.splice(1, familyMembersList.length - 1)
     }
 
@@ -120,7 +129,7 @@ export class FamilyParticipant extends Component {
       ...draft,
       familyData: {
         ...draft.familyData,
-        countFamilyMembers: value,
+        countFamilyMembers: valueIsNumber ? value : undefined,
         familyMembersList
       }
     })


### PR DESCRIPTION
**Problem**
The problem is located inside the _addFamily_ count method in Primary Participant screen. Previously we had a problem when the passed parameter was negative -1 when "PREFER NOT TO SAY" option was selected. This time we have a certain case when empty string is passed to the function as parameter. The problem is when the dropdown is opened and the user decides not to click on any of the options, but instead click on the overlay of the modal to close the dropdown. In that case a _validateInput()_ method is being called(inside the Select component) with parameter empty string. Then inside addFamilyCount the first if statement meets the check and the whole object representing the primary participant is been sliced.

**Solution**
I added a check, if the passed parameter is number, inside the **addFamilyCount**. If it's not a number (which means the the user chooses not to click on any of the options, but on the overlay to close the dropdown) the countFamilyMembers property becomes undefined and all of the objects created for family members will be deleted except for the primary participant.