### PR TITLE
Offlini/Online functionality for sending email at the end of the lifemap

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -213,7 +213,8 @@
     "final": {
       "emailSent": "Your Life Map has been successfully sent via email. Don't forget to click on Save & Close!",
       "emailError": "Error while trying to send your Life Map via email",
-      "offlineText": "Please enable your internet connection to receive your Life Map via email."
+      "offlineText": "Please enable your internet connection to receive your Life Map via email.",
+      "yourLifeMaWillBeSentWithSurveySync": "Your Life Map will be sent to your email as soon as the survey is synced. Click 'Close' to finish the survey!"
     }
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -214,7 +214,8 @@
     "final": {
       "emailSent": "Tu Mapa de Vida ha sido enviado exitosamente vía email. ¡No te olvides de seleccionar Guardar & cerrar!",
       "emailError": "Error al enviar tu Mapa de Vida vía email",
-      "offlineText": "Por favor, activa tu conexión a Internet para recibir tu Mapa de Vida vía email"
+      "offlineText": "Por favor, activa tu conexión a Internet para recibir tu Mapa de Vida vía email",
+      "yourLifeMaWillBeSentWithSurveySync": "Tu Mapa de Vida será enviado a tu correo cuando tu encuesta esté sincronizada. ¡Selecciona 'Cerrar' para terminar la encuesta!"
     }
   }
 }

--- a/src/screens/lifemap/FamilyParticipant.js
+++ b/src/screens/lifemap/FamilyParticipant.js
@@ -1,21 +1,21 @@
-import React, { Component } from 'react'
-import { StyleSheet, Text } from 'react-native'
-import { createDraft, updateDraft } from '../../redux/actions'
-import { getTotalScreens, setValidationSchema } from './helpers'
-
-import DateInput from '../../components/form/DateInput'
-import Decoration from '../../components/decoration/Decoration'
-import Icon from 'react-native-vector-icons/MaterialIcons'
 import PropTypes from 'prop-types'
-import Select from '../../components/form/Select'
-import StickyFooter from '../../components/StickyFooter'
-import TextInput from '../../components/form/TextInput'
-import colors from '../../theme.json'
-import { connect } from 'react-redux'
-import globalStyles from '../../globalStyles'
-import uuid from 'uuid/v1'
+import React, { Component } from 'react'
 import { withNamespaces } from 'react-i18next'
+import { StyleSheet, Text } from 'react-native'
+import Icon from 'react-native-vector-icons/MaterialIcons'
+import { connect } from 'react-redux'
+import uuid from 'uuid/v1'
+
+import Decoration from '../../components/decoration/Decoration'
+import DateInput from '../../components/form/DateInput'
+import Select from '../../components/form/Select'
+import TextInput from '../../components/form/TextInput'
+import StickyFooter from '../../components/StickyFooter'
+import globalStyles from '../../globalStyles'
+import { createDraft, updateDraft } from '../../redux/actions'
+import colors from '../../theme.json'
 import { generateNewDemoDraft } from '../utils/helpers'
+import { getTotalScreens, setValidationSchema } from './helpers'
 
 export class FamilyParticipant extends Component {
   survey = this.props.navigation.getParam('survey')
@@ -194,6 +194,7 @@ export class FamilyParticipant extends Component {
 
     const regularDraft = {
       draftId,
+      sendEmail: false,
       created: Date.now(),
       status: 'Draft',
       surveyId: this.survey.id,

--- a/src/screens/lifemap/__tests__/FamilyParticipant.test.js
+++ b/src/screens/lifemap/__tests__/FamilyParticipant.test.js
@@ -1,8 +1,9 @@
-import { FamilyParticipant } from '../FamilyParticipant'
-import React from 'react'
-import StickyFooter from '../../../components/StickyFooter'
-import TextInput from '../../../components/form/TextInput'
 import { shallow } from 'enzyme'
+import React from 'react'
+
+import TextInput from '../../../components/form/TextInput'
+import StickyFooter from '../../../components/StickyFooter'
+import { FamilyParticipant } from '../FamilyParticipant'
 
 // props
 const survey = {
@@ -50,6 +51,7 @@ const survey = {
 
 const defaultDraft = {
   draftId: expect.any(String),
+  sendEmail: false,
   created: expect.any(Number),
   status: 'Draft',
   surveyId: 1,

--- a/src/screens/modals/EmailSentModal.js
+++ b/src/screens/modals/EmailSentModal.js
@@ -48,7 +48,7 @@ class EmailSentModal extends Component {
             ) : (
               <View>
                 <Text style={styles.paragraph}>
-                  {i18n.t('views.final.offlineText')}
+                  {i18n.t('views.final.yourLifeMaWillBeSentWithSurveySync')}
                 </Text>
               </View>
             )}

--- a/src/screens/utils/demo_draft_generator.js
+++ b/src/screens/utils/demo_draft_generator.js
@@ -7,6 +7,7 @@ export const generateRandomDraftData = (
 ) => {
   return {
     status: 'Draft',
+    sendEmail: false,
     surveyId,
     created: Date.now(),
     draftId,


### PR DESCRIPTION
Implemented the following requirements 

```
1. The user press the email button, the app will store a flag "sendEmail" along with the draft data to send it later in the sync process, and the app shows a modal with the next texts:

English: Your Life Map will be sent to your email as soon as the survey is synced. Click "Close" to finish the survey!

Spanish: Tu Mapa de Vida será enviado a tu correo cuando tu encuesta esté sincronizada. ¡Selecciona "Cerrar" para terminar la encuesta!

2. When the app syncs the draft, the server will check the "sendEmail" flag and send the lifemap if this flag was set to true.
```