### PR TITLE
Bugfix/1151/conditional bug

### DIFF
--- a/src/screens/utils/conditional_logic.js
+++ b/src/screens/utils/conditional_logic.js
@@ -328,13 +328,13 @@ export const shouldCleanUp = (
     )
   }
 
-  const answerWithNoKey = currentAnswer
+  const answerWithEmptyValue = currentAnswer
     ? currentAnswer.multipleValue
-      ? !currentAnswer.multipleValue
+      ? !currentAnswer.multipleValue.length
       : !currentAnswer.value
     : null
 
-  if (!currentAnswer || answerWithNoKey) {
+  if (!currentAnswer || answerWithEmptyValue) {
     return false
   }
   let cleanUp = false

--- a/src/screens/utils/conditional_logic.js
+++ b/src/screens/utils/conditional_logic.js
@@ -327,7 +327,14 @@ export const shouldCleanUp = (
       ea => ea.key === conditionalQuestion.codeName
     )
   }
-  if (!currentAnswer || !currentAnswer.value) {
+
+  const answerWithNoKey = currentAnswer
+    ? currentAnswer.multipleValue
+      ? !currentAnswer.multipleValue
+      : !currentAnswer.value
+    : null
+
+  if (!currentAnswer || answerWithNoKey) {
     return false
   }
   let cleanUp = false

--- a/src/screens/utils/helpers.js
+++ b/src/screens/utils/helpers.js
@@ -1,5 +1,9 @@
-import { generateRandomDraftData } from './demo_draft_generator'
 import { getTotalScreens } from '../lifemap/helpers'
+import {
+  getConditionalQuestions,
+  getDraftWithUpdatedQuestionsCascading
+} from '../utils/conditional_logic'
+import { generateRandomDraftData } from './demo_draft_generator'
 
 const LATIN_CHARS = /^[A-Za-z0-9]*$/
 
@@ -18,8 +22,18 @@ export const checkAndReplaceSpecialChars = question => {
 }
 
 export const prepareDraftForSubmit = (draft, survey) => {
+  const conditionalQuestions = getConditionalQuestions(survey)
+  const currentDraft = getDraftWithUpdatedQuestionsCascading(
+    draft,
+    conditionalQuestions,
+    false
+  )
+
   // remove unnecessary for sync properties from saved draft
-  const { progress, errors, status, ...result } = Object.assign({}, draft)
+  const { progress, errors, status, ...result } = Object.assign(
+    {},
+    currentDraft
+  )
 
   // we remove
   progress


### PR DESCRIPTION
***

#### Main problem occurs when having socio economic answers with multiple values ( checkboxes ), where the key for the answer inside the `socioEconomicAnawer` array is `multipleValue`

---

This issue fixes problem with cleaning values for conditional questions: values with `multipleValue` keys. Also added cleaning up conditional answers from the draft at the Final screen. 

The main problem causing the issue was the following check inside the `shouldCleanup` method, which checks only for `value` key and never for `multipleValue` and the method was always returning `false` and never showing indication that the conditional answer should be cleaned when having answers which are array with `multipleValue` key. 

 ```
  if (!currentAnswer || currentAnswer.value) {
    return false
  }
```

The addition of the conditional answer cleaning at the Final screen should fix all the stuck drafts  with `Sync error` when resubmitted.

## To test  
Follow Ana's description inside the issue: 
[http://app.lab.penguin.academy/admin/requests/5e1488003145310017c47d15](http://app.lab.penguin.academy/admin/requests/5e1488003145310017c47d15)

_Survey_: Red de Empresas
_Screen_: Datos de la familia
_Question_:  Situacion de la vivienda (based on the answers , other question should show or hide)

You can log the draft to look specifically for the following object inside it (question: `Situacion de la vivienda`, occurs when changing the answers from `Propia con titulo` to `Propiedad familiar` and vice versa):  
`{key: "ownerOfTitle", multipleValue: Array(3)}`
