### PR TITLE
Priorities Crash Fix

### DIFF
--- a/src/components/LifemapOverview.js
+++ b/src/components/LifemapOverview.js
@@ -1,9 +1,10 @@
-import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { StyleSheet, View, Text } from 'react-native'
-import LifemapOverviewListItem from './LifemapOverviewListItem'
-import AddPriorityAndAchievementModal from '../screens/modals/AddPriorityAndAchievementModal'
+import React, { Component } from 'react'
+import { StyleSheet, Text, View } from 'react-native'
+
 import globalStyles from '../globalStyles'
+import AddPriorityAndAchievementModal from '../screens/modals/AddPriorityAndAchievementModal'
+import LifemapOverviewListItem from './LifemapOverviewListItem'
 
 class LifemapOverview extends Component {
   dimensions = this.props.surveyData.map(item => item.dimension)
@@ -80,7 +81,7 @@ class LifemapOverview extends Component {
           <AddPriorityAndAchievementModal
             onClose={this.onClose}
             color={this.state.color}
-            draftId={this.props.draftData.draftId}
+            draft={this.props.draftData}
             indicator={this.state.indicator}
             indicatorText={this.state.indicatorText}
           />

--- a/src/screens/modals/AddPriorityAndAchievementModal.js
+++ b/src/screens/modals/AddPriorityAndAchievementModal.js
@@ -65,8 +65,13 @@ export class AddPriorityAndAchievementModal extends Component {
     return this.setState({ estimatedDate: action })
   }
 
-  getDraft = () =>
-    this.props.drafts.find(draft => draft.draftId === this.draftId)
+  getDraft = () => {
+    if (this.draftId) {
+      return this.props.drafts.find(draft => draft.draftId === this.draftId)
+    } else {
+      return this.props.draft
+    }
+  }
 
   addPriority = () => {
     const draft = this.getDraft()
@@ -184,7 +189,13 @@ export class AddPriorityAndAchievementModal extends Component {
     const draft = this.getDraft()
     const { t } = this.props
     const { validationError, showErrors } = this.state
-    const isReadOnly = draft.status === 'Synced'
+    var isReadOnly = false
+
+    if (draft.status) {
+      isReadOnly = draft.status === 'Synced'
+    } else {
+      isReadOnly = true
+    }
 
     //i cound directly use this.state.action for the values below but
     // it just doesnt work.Thats why i use the old way from the old components
@@ -330,7 +341,8 @@ AddPriorityAndAchievementModal.propTypes = {
   onClose: PropTypes.func,
   updateDraft: PropTypes.func.isRequired,
   draftId: PropTypes.number,
-  drafts: PropTypes.array.isRequired
+  drafts: PropTypes.array.isRequired,
+  readOnly: PropTypes.bool
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
This pr fixed the app crash when clicking on priorities or achievements in readOnly screens like family.
