### PR TITLE
phoneCode crash fix

### DIFF
--- a/src/redux/__tests__/actions.test.js
+++ b/src/redux/__tests__/actions.test.js
@@ -107,7 +107,7 @@ describe('families actions', () => {
           rollback: { type: 'LOAD_FAMILIES_ROLLBACK' },
           effect: {
             body:
-              '{"query":"query { familiesNewStructure {familyId name code snapshotList { surveyId createdAt familyData { familyMembersList { birthCountry birthDate documentNumber documentType email familyId firstName firstParticipant gender id lastName memberIdentifier phoneCode phoneNumber socioEconomicAnswers { key value}  }  countFamilyMembers latitude longitude country accuracy } economicSurveyDataList { key value multipleValue } indicatorSurveyDataList { key value } achievements { action indicator roadmap } priorities { action estimatedDate indicator reason } } } }"}',
+              '{"query":"query { familiesNewStructure {familyId name code snapshotList { surveyId stoplightSkipped createdAt familyData { familyMembersList { birthCountry birthDate documentNumber documentType email familyId firstName firstParticipant gender id lastName memberIdentifier phoneCode phoneNumber socioEconomicAnswers { key value}  }  countFamilyMembers latitude longitude country accuracy } economicSurveyDataList { key value multipleValue } indicatorSurveyDataList { key value } achievements { action indicator roadmap } priorities { action estimatedDate indicator reason } } } }"}',
             headers: {
               Authorization: 'Bearer token',
               'content-type': 'application/json;charset=utf8'

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -191,8 +191,8 @@ export const addSurveyData = (id, category, payload) => ({
 })
 
 const formatPhone = (code, phone) => {
-  const phoneUtil = PhoneNumberUtil.getInstance()
-  if (phone && phone.length > 0) {
+  if (code && phone && phone.length > 0) {
+    const phoneUtil = PhoneNumberUtil.getInstance()
     const international = '+' + code + ' ' + phone
     let phoneNumber = phoneUtil.parse(international, code)
     phone = phoneNumber.getNationalNumber()

--- a/src/screens/lifemap/FamilyParticipant.js
+++ b/src/screens/lifemap/FamilyParticipant.js
@@ -176,7 +176,7 @@ export class FamilyParticipant extends Component {
   }
 
   updateParticipant = (value, field) => {
-    if (this.readOnly) {
+    if (this.readOnly || (!value && field == 'phoneCode')) {
       return
     }
 
@@ -288,6 +288,7 @@ export class FamilyParticipant extends Component {
     const { showErrors } = this.state
     const draft = !this.readOnly ? this.getDraft() : this.readOnlyDraft
     let participant = draft ? draft.familyData.familyMembersList[0] : {}
+
     return draft ? (
       <StickyFooter
         onContinue={this.validateForm}


### PR DESCRIPTION
This fixes the crash of the app when we dont have a phoneCode.
To test:
- go to the phone code dropdown and click outside (dont select anything), this should not change the current draft and therefore should noit have an empty string as a phone code.
- submit the draft and check if you have any warnings/crashes.
- for the older devices that had this bug and currently have an empty string as a phoneCode, you can test if it crashes but submitting it ,however if you want the phone number actually formatted then select a value from the phone code dropdown and submit the draft.
